### PR TITLE
feat: 支持自定义 Ingress Class 配置

### DIFF
--- a/context-loader/agent-retrieval/helm/agent-retrieval/templates/ingress.yaml
+++ b/context-loader/agent-retrieval/helm/agent-retrieval/templates/ingress.yaml
@@ -16,7 +16,9 @@ metadata:
     nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
     nginx.ingress.kubernetes.io/proxy-body-size: 2048m
 spec:
-  ingressClassName: class-443
+{{- if index .Values.depServices "class-443" "ingressClass" }}
+  ingressClassName: {{ index .Values.depServices "class-443" "ingressClass" }}
+{{- end }}
   rules:
   - http:
       paths:

--- a/context-loader/agent-retrieval/helm/agent-retrieval/values.yaml
+++ b/context-loader/agent-retrieval/helm/agent-retrieval/values.yaml
@@ -132,6 +132,8 @@ depServices:
     caName: ""
     certName: ""
     keyName: ""
+  class-443:
+    ingressClass: class-443
 
 env:
   language: en_US.UTF-8


### PR DESCRIPTION
重构 ingress.yaml，从 values.yaml 中读取 ingressClassName，不再硬编码为 class-443。
此次修改使配置方式与其他服务（如 ontology-query）保持一致，支持自定义 Ingress Class。
变更内容：
- templates/ingress.yaml: 将硬编码的 'class-443' 替换为动态模板变量
- values.yaml: 在 depServices 中添加 'class-443' 配置项