### PR TITLE
fix(bkn): 导入时 fail-fast 校验向量模型引用

### DIFF
--- a/bkn/bkn-backend/server/driveradapters/bkn_handler.go
+++ b/bkn/bkn-backend/server/driveradapters/bkn_handler.go
@@ -157,6 +157,16 @@ func (r *restHandler) UploadBKN(c *gin.Context) {
 			return
 		}
 	}
+	// 校验向量配置引用的模型在目标环境中是否存在
+	if len(kn.ObjectTypes) > 0 {
+		err = ValidateVectorModelRefs(ctx, kn.ObjectTypes, r.mfa)
+		if err != nil {
+			httpErr := err.(*rest.HTTPError)
+			o11y.AddHttpAttrs4HttpError(span, httpErr)
+			rest.ReplyError(c, httpErr)
+			return
+		}
+	}
 	if len(kn.RelationTypes) > 0 {
 		err = ValidateRelationTypes(ctx, kn.KNID, kn.RelationTypes)
 		if err != nil {

--- a/bkn/bkn-backend/server/driveradapters/routers.go
+++ b/bkn/bkn-backend/server/driveradapters/routers.go
@@ -22,6 +22,7 @@ import (
 	"bkn-backend/common"
 	berrors "bkn-backend/errors"
 	"bkn-backend/interfaces"
+	"bkn-backend/logics"
 	"bkn-backend/logics/action_schedule"
 	"bkn-backend/logics/action_type"
 	"bkn-backend/logics/bkn"
@@ -45,6 +46,7 @@ type restHandler struct {
 	cgs        interfaces.ConceptGroupService
 	js         interfaces.JobService
 	kns        interfaces.KNService
+	mfa        interfaces.ModelFactoryAccess
 	ots        interfaces.ObjectTypeService
 	rts        interfaces.RelationTypeService
 	bs         interfaces.BKNService
@@ -59,6 +61,7 @@ func NewRestHandler(appSetting *common.AppSetting) RestHandler {
 		cgs:        concept_group.NewConceptGroupService(appSetting),
 		js:         job.NewJobService(appSetting),
 		kns:        knowledge_network.NewKNService(appSetting),
+		mfa:        logics.MFA,
 		ots:        object_type.NewObjectTypeService(appSetting),
 		rts:        relation_type.NewRelationTypeService(appSetting),
 		bs:         bkn.NewBKNService(appSetting),

--- a/bkn/bkn-backend/server/driveradapters/validate_object_type.go
+++ b/bkn/bkn-backend/server/driveradapters/validate_object_type.go
@@ -437,3 +437,41 @@ func ValidateVectorConfig(ctx context.Context, vectorConfig interfaces.VectorCon
 	}
 	return nil
 }
+
+// ValidateVectorModelRefs 校验所有对象类中向量配置引用的模型是否在目标环境中存在且有效。
+// 用于导入时 fail-fast，避免脏数据进入系统。
+func ValidateVectorModelRefs(ctx context.Context, objectTypes []*interfaces.ObjectType, mfa interfaces.ModelFactoryAccess) error {
+	for _, ot := range objectTypes {
+		for _, prop := range ot.DataProperties {
+			if prop.IndexConfig == nil || !prop.IndexConfig.VectorConfig.Enabled {
+				continue
+			}
+			modelID := prop.IndexConfig.VectorConfig.ModelID
+			if modelID == "" {
+				continue
+			}
+			model, err := mfa.GetModelByID(ctx, modelID)
+			if err != nil {
+				return rest.NewHTTPError(ctx, http.StatusInternalServerError,
+					berrors.BknBackend_ObjectType_InternalError_GetSmallModelByIDFailed).
+					WithErrorDetails(fmt.Sprintf("对象类[%s]属性[%s]: %s", ot.OTName, prop.Name, err.Error()))
+			}
+			if model == nil {
+				return rest.NewHTTPError(ctx, http.StatusBadRequest,
+					berrors.BknBackend_ObjectType_SmallModelNotFound).
+					WithErrorDetails(fmt.Sprintf("对象类[%s]属性[%s]引用的模型[%s]在目标环境中不存在", ot.OTName, prop.Name, modelID))
+			}
+			if model.ModelType != interfaces.SMALL_MODEL_TYPE_EMBEDDING {
+				return rest.NewHTTPError(ctx, http.StatusBadRequest,
+					berrors.BknBackend_ObjectType_InvalidParameter_SmallModel).
+					WithErrorDetails(fmt.Sprintf("对象类[%s]属性[%s]引用的模型[%s]类型为[%s]，不是embedding模型", ot.OTName, prop.Name, modelID, model.ModelType))
+			}
+			if model.EmbeddingDim == 0 || model.BatchSize == 0 || model.MaxTokens == 0 {
+				return rest.NewHTTPError(ctx, http.StatusBadRequest,
+					berrors.BknBackend_ObjectType_InvalidParameter_SmallModel).
+					WithErrorDetails(fmt.Sprintf("对象类[%s]属性[%s]引用的模型[%s]参数无效(embedding_dim/batch_size/max_tokens)", ot.OTName, prop.Name, modelID))
+			}
+		}
+	}
+	return nil
+}

--- a/bkn/bkn-backend/server/driveradapters/validate_object_type_test.go
+++ b/bkn/bkn-backend/server/driveradapters/validate_object_type_test.go
@@ -7,13 +7,16 @@ package driveradapters
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/kweaver-ai/kweaver-go-lib/rest"
 	. "github.com/smartystreets/goconvey/convey"
+	"go.uber.org/mock/gomock"
 
 	berrors "bkn-backend/errors"
 	"bkn-backend/interfaces"
+	mockInterfaces "bkn-backend/interfaces/mock"
 )
 
 func Test_ValidateObjectType(t *testing.T) {
@@ -697,6 +700,176 @@ func Test_ValidateVectorConfig(t *testing.T) {
 			}
 			err := ValidateVectorConfig(ctx, config)
 			So(err, ShouldNotBeNil)
+		})
+	})
+}
+
+func Test_ValidateVectorModelRefs(t *testing.T) {
+	Convey("Test ValidateVectorModelRefs\n", t, func() {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		ctx := context.Background()
+		mockMFA := mockInterfaces.NewMockModelFactoryAccess(ctrl)
+
+		Convey("Success with no vector config enabled\n", func() {
+			objectTypes := []*interfaces.ObjectType{
+				{
+					ObjectTypeWithKeyField: interfaces.ObjectTypeWithKeyField{
+						OTName: "ot1",
+						DataProperties: []*interfaces.DataProperty{
+							{Name: "prop1", Type: "string"},
+						},
+					},
+				},
+			}
+			err := ValidateVectorModelRefs(ctx, objectTypes, mockMFA)
+			So(err, ShouldBeNil)
+		})
+
+		Convey("Success with valid model reference\n", func() {
+			objectTypes := []*interfaces.ObjectType{
+				{
+					ObjectTypeWithKeyField: interfaces.ObjectTypeWithKeyField{
+						OTName: "ot1",
+						DataProperties: []*interfaces.DataProperty{
+							{
+								Name: "prop1",
+								IndexConfig: &interfaces.IndexConfig{
+									VectorConfig: interfaces.VectorConfig{
+										Enabled: true,
+										ModelID: "model1",
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			mockMFA.EXPECT().GetModelByID(gomock.Any(), "model1").Return(&interfaces.SmallModel{
+				ModelID:      "model1",
+				ModelType:    interfaces.SMALL_MODEL_TYPE_EMBEDDING,
+				EmbeddingDim: 768,
+				BatchSize:    32,
+				MaxTokens:    512,
+			}, nil)
+			err := ValidateVectorModelRefs(ctx, objectTypes, mockMFA)
+			So(err, ShouldBeNil)
+		})
+
+		Convey("Failed when GetModelByID returns error\n", func() {
+			objectTypes := []*interfaces.ObjectType{
+				{
+					ObjectTypeWithKeyField: interfaces.ObjectTypeWithKeyField{
+						OTName: "ot1",
+						DataProperties: []*interfaces.DataProperty{
+							{
+								Name: "prop1",
+								IndexConfig: &interfaces.IndexConfig{
+									VectorConfig: interfaces.VectorConfig{
+										Enabled: true,
+										ModelID: "model1",
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			mockMFA.EXPECT().GetModelByID(gomock.Any(), "model1").Return(nil, errors.New("connection refused"))
+			err := ValidateVectorModelRefs(ctx, objectTypes, mockMFA)
+			So(err, ShouldNotBeNil)
+			httpErr := err.(*rest.HTTPError)
+			So(httpErr.BaseError.ErrorCode, ShouldEqual, berrors.BknBackend_ObjectType_InternalError_GetSmallModelByIDFailed)
+		})
+
+		Convey("Failed with non-existent model\n", func() {
+			objectTypes := []*interfaces.ObjectType{
+				{
+					ObjectTypeWithKeyField: interfaces.ObjectTypeWithKeyField{
+						OTName: "ot1",
+						DataProperties: []*interfaces.DataProperty{
+							{
+								Name: "prop1",
+								IndexConfig: &interfaces.IndexConfig{
+									VectorConfig: interfaces.VectorConfig{
+										Enabled: true,
+										ModelID: "missing-model",
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			mockMFA.EXPECT().GetModelByID(gomock.Any(), "missing-model").Return(nil, nil)
+			err := ValidateVectorModelRefs(ctx, objectTypes, mockMFA)
+			So(err, ShouldNotBeNil)
+			httpErr := err.(*rest.HTTPError)
+			So(httpErr.BaseError.ErrorCode, ShouldEqual, berrors.BknBackend_ObjectType_SmallModelNotFound)
+		})
+
+		Convey("Failed with wrong model type\n", func() {
+			objectTypes := []*interfaces.ObjectType{
+				{
+					ObjectTypeWithKeyField: interfaces.ObjectTypeWithKeyField{
+						OTName: "ot1",
+						DataProperties: []*interfaces.DataProperty{
+							{
+								Name: "prop1",
+								IndexConfig: &interfaces.IndexConfig{
+									VectorConfig: interfaces.VectorConfig{
+										Enabled: true,
+										ModelID: "model-llm",
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			mockMFA.EXPECT().GetModelByID(gomock.Any(), "model-llm").Return(&interfaces.SmallModel{
+				ModelID:      "model-llm",
+				ModelType:    "llm",
+				EmbeddingDim: 768,
+				BatchSize:    32,
+				MaxTokens:    512,
+			}, nil)
+			err := ValidateVectorModelRefs(ctx, objectTypes, mockMFA)
+			So(err, ShouldNotBeNil)
+			httpErr := err.(*rest.HTTPError)
+			So(httpErr.BaseError.ErrorCode, ShouldEqual, berrors.BknBackend_ObjectType_InvalidParameter_SmallModel)
+		})
+
+		Convey("Failed with invalid model params\n", func() {
+			objectTypes := []*interfaces.ObjectType{
+				{
+					ObjectTypeWithKeyField: interfaces.ObjectTypeWithKeyField{
+						OTName: "ot1",
+						DataProperties: []*interfaces.DataProperty{
+							{
+								Name: "prop1",
+								IndexConfig: &interfaces.IndexConfig{
+									VectorConfig: interfaces.VectorConfig{
+										Enabled: true,
+										ModelID: "model-bad",
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			mockMFA.EXPECT().GetModelByID(gomock.Any(), "model-bad").Return(&interfaces.SmallModel{
+				ModelID:      "model-bad",
+				ModelType:    interfaces.SMALL_MODEL_TYPE_EMBEDDING,
+				EmbeddingDim: 0,
+				BatchSize:    0,
+				MaxTokens:    0,
+			}, nil)
+			err := ValidateVectorModelRefs(ctx, objectTypes, mockMFA)
+			So(err, ShouldNotBeNil)
+			httpErr := err.(*rest.HTTPError)
+			So(httpErr.BaseError.ErrorCode, ShouldEqual, berrors.BknBackend_ObjectType_InvalidParameter_SmallModel)
 		})
 	})
 }


### PR DESCRIPTION
## Summary
- 新增 `ValidateVectorModelRefs` 函数，校验导入数据中 `vector_config` 引用的模型在目标环境中是否存在且有效
- 在 `UploadBKN` handler 中 `ValidateObjectTypes` 之后调用，模型不存在则直接拒绝导入（400 + 明确错误信息）
- `restHandler` 新增 `mfa` 字段以接入 `ModelFactoryAccess`

## 根因
导入 API 只检查 `ModelID != ""`，不验证模型是否真实存在；保存 API 严格校验模型存在性。导致导入成功但后续编辑报错 `GetSmallModelByIDFailed`。

## Test plan
- [x] 无向量配置 → 校验通过
- [x] 有效模型引用 → 校验通过
- [x] GetModelByID 返回 error → 返回 InternalError
- [x] 模型不存在（nil）→ 返回 SmallModelNotFound
- [x] 模型类型不是 embedding → 返回 InvalidParameter
- [x] 模型参数无效（dim/batch/tokens=0）→ 返回 InvalidParameter
- [x] 全量测试通过 `go test ./...`

Closes #352

🤖 Generated with [Claude Code](https://claude.com/claude-code)