### PR TITLE
feat(关系类): 移除关系类名称唯一性约束，允许同一BKN内同名关系类存在

### DIFF
--- a/bkn/bkn-backend/migrations/dm8/0.5.0/pre/01-alter-table.sql
+++ b/bkn/bkn-backend/migrations/dm8/0.5.0/pre/01-alter-table.sql
@@ -1,0 +1,9 @@
+-- Copyright The kweaver.ai Authors.
+--
+-- Licensed under the Apache License, Version 2.0.
+-- See the LICENSE file in the project root for details.
+
+USE adp;
+
+-- 移除关系类名称唯一性约束，同一 BKN 内允许同名关系类存在
+DROP INDEX IF EXISTS adp.uk_t_relation_type_rt_name;

--- a/bkn/bkn-backend/migrations/dm8/0.5.0/pre/init.sql
+++ b/bkn/bkn-backend/migrations/dm8/0.5.0/pre/init.sql
@@ -1,0 +1,228 @@
+-- Copyright The kweaver.ai Authors.
+--
+-- Licensed under the Apache License, Version 2.0.
+-- See the LICENSE file in the project root for details.
+
+SET SCHEMA adp;
+
+CREATE TABLE IF NOT EXISTS t_knowledge_network (
+  f_id VARCHAR(40 CHAR) NOT NULL DEFAULT '',
+  f_name VARCHAR(40 CHAR) NOT NULL DEFAULT '',
+  f_tags VARCHAR(255 CHAR) DEFAULT NULL,
+  f_comment VARCHAR(1000 CHAR) NOT NULL DEFAULT '',
+  f_icon VARCHAR(255 CHAR) NOT NULL DEFAULT '',
+  f_color VARCHAR(40 CHAR) NOT NULL DEFAULT '',
+  f_bkn_raw_content TEXT DEFAULT NULL,
+  f_branch VARCHAR(40 CHAR) NOT NULL DEFAULT '',
+  f_business_domain VARCHAR(40 CHAR) NOT NULL DEFAULT '',
+  f_creator VARCHAR(40 CHAR) NOT NULL DEFAULT '',
+  f_creator_type VARCHAR(40 CHAR) NOT NULL DEFAULT '',
+  f_create_time BIGINT NOT NULL DEFAULT 0,
+  f_updater VARCHAR(40 CHAR) NOT NULL DEFAULT '',
+  f_updater_type VARCHAR(40 CHAR) NOT NULL DEFAULT '',
+  f_update_time BIGINT NOT NULL DEFAULT 0,
+  CLUSTER PRIMARY KEY (f_id,f_branch)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uk_t_knowledge_network_kn_name ON t_knowledge_network(f_name,f_branch);
+
+
+CREATE TABLE IF NOT EXISTS t_object_type (
+  f_id VARCHAR(40 CHAR) NOT NULL DEFAULT '',
+  f_name VARCHAR(40 CHAR) NOT NULL DEFAULT '',
+  f_tags VARCHAR(255 CHAR) DEFAULT NULL,
+  f_comment VARCHAR(1000 CHAR) NOT NULL DEFAULT '',
+  f_icon VARCHAR(255 CHAR) NOT NULL DEFAULT '',
+  f_color VARCHAR(40 CHAR) NOT NULL DEFAULT '',
+  f_bkn_raw_content TEXT DEFAULT NULL,
+  f_kn_id VARCHAR(40 CHAR) NOT NULL DEFAULT '',
+  f_branch VARCHAR(40 CHAR) NOT NULL DEFAULT '',
+  f_data_source VARCHAR(255 CHAR) NOT NULL,
+  f_data_properties TEXT DEFAULT NULL,
+  f_logic_properties TEXT DEFAULT NULL,
+  f_primary_keys VARCHAR(8192 CHAR) DEFAULT NULL,
+  f_display_key VARCHAR(40 CHAR) NOT NULL DEFAULT '',
+  f_incremental_key VARCHAR(40 CHAR) NOT NULL DEFAULT '',
+  f_creator VARCHAR(40 CHAR) NOT NULL DEFAULT '',
+  f_creator_type VARCHAR(40 CHAR) NOT NULL DEFAULT '',
+  f_create_time BIGINT NOT NULL DEFAULT 0,
+  f_updater VARCHAR(40 CHAR) NOT NULL DEFAULT '',
+  f_updater_type VARCHAR(40 CHAR) NOT NULL DEFAULT '',
+  f_update_time BIGINT NOT NULL DEFAULT 0,
+  CLUSTER PRIMARY KEY (f_kn_id,f_branch,f_id)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uk_t_object_type_ot_name ON t_object_type(f_kn_id,f_branch,f_name);
+
+
+-- 对象类状态
+CREATE TABLE IF NOT EXISTS t_object_type_status (
+  f_id VARCHAR(40 CHAR) NOT NULL DEFAULT '',
+  f_kn_id VARCHAR(40 CHAR) NOT NULL DEFAULT '',
+  f_branch VARCHAR(40 CHAR) NOT NULL DEFAULT '',
+  f_incremental_key VARCHAR(40 CHAR) NOT NULL DEFAULT '',
+  f_incremental_value VARCHAR(40 CHAR) NOT NULL DEFAULT '',
+  f_index VARCHAR(255 CHAR) NOT NULL DEFAULT '',
+  f_index_available BIT NOT NULL DEFAULT 0,
+  f_doc_count BIGINT NOT NULL DEFAULT 0,
+  f_storage_size BIGINT NOT NULL DEFAULT 0,
+  f_update_time BIGINT NOT NULL DEFAULT 0,
+  CLUSTER PRIMARY KEY (f_kn_id,f_branch,f_id)
+);
+
+
+CREATE TABLE IF NOT EXISTS t_relation_type (
+  f_id VARCHAR(40 CHAR) NOT NULL DEFAULT '',
+  f_name VARCHAR(40 CHAR) NOT NULL DEFAULT '',
+  f_tags VARCHAR(255 CHAR) DEFAULT NULL,
+  f_comment VARCHAR(1000 CHAR) NOT NULL DEFAULT '',
+  f_icon VARCHAR(255 CHAR) NOT NULL DEFAULT '',
+  f_color VARCHAR(40 CHAR) NOT NULL DEFAULT '',
+  f_bkn_raw_content TEXT DEFAULT NULL,
+  f_kn_id VARCHAR(40 CHAR) NOT NULL DEFAULT '',
+  f_branch VARCHAR(40 CHAR) NOT NULL DEFAULT '',
+  f_source_object_type_id VARCHAR(40 CHAR) NOT NULL DEFAULT '',
+  f_target_object_type_id VARCHAR(40 CHAR) NOT NULL DEFAULT '',
+  f_type VARCHAR(40 CHAR) NOT NULL DEFAULT '',
+  f_mapping_rules text DEFAULT NULL,
+  f_creator VARCHAR(40 CHAR) NOT NULL DEFAULT '',
+  f_creator_type VARCHAR(40 CHAR) NOT NULL DEFAULT '',
+  f_create_time BIGINT NOT NULL DEFAULT 0,
+  f_updater VARCHAR(40 CHAR) NOT NULL DEFAULT '',
+  f_updater_type VARCHAR(40 CHAR) NOT NULL DEFAULT '',
+  f_update_time BIGINT NOT NULL DEFAULT 0,
+  CLUSTER PRIMARY KEY (f_kn_id,f_branch,f_id)
+);
+
+
+CREATE TABLE IF NOT EXISTS t_action_type (
+  f_id VARCHAR(40 CHAR) NOT NULL DEFAULT '',
+  f_name VARCHAR(40 CHAR) NOT NULL DEFAULT '',
+  f_tags VARCHAR(255 CHAR) DEFAULT NULL,
+  f_comment VARCHAR(1000 CHAR) NOT NULL DEFAULT '',
+  f_icon VARCHAR(255 CHAR) NOT NULL DEFAULT '',
+  f_color VARCHAR(40 CHAR) NOT NULL DEFAULT '',
+  f_bkn_raw_content TEXT DEFAULT NULL,
+  f_kn_id VARCHAR(40 CHAR) NOT NULL DEFAULT '',
+  f_branch VARCHAR(40 CHAR) NOT NULL DEFAULT '',
+  f_action_type VARCHAR(40 CHAR) NOT NULL DEFAULT '',
+  f_object_type_id VARCHAR(40 CHAR) NOT NULL DEFAULT '',
+  f_condition TEXT DEFAULT NULL,
+  f_affect TEXT DEFAULT NULL,
+  f_action_source VARCHAR(255 CHAR) NOT NULL,
+  f_parameters TEXT DEFAULT NULL,
+  f_schedule VARCHAR(255 CHAR) DEFAULT NULL,
+  f_creator VARCHAR(40 CHAR) NOT NULL DEFAULT '',
+  f_creator_type VARCHAR(40 CHAR) NOT NULL DEFAULT '',
+  f_create_time BIGINT NOT NULL DEFAULT 0,
+  f_updater VARCHAR(40 CHAR) NOT NULL DEFAULT '',
+  f_updater_type VARCHAR(40 CHAR) NOT NULL DEFAULT '',
+  f_update_time BIGINT NOT NULL DEFAULT 0,
+  CLUSTER PRIMARY KEY (f_kn_id,f_branch,f_id)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uk_t_action_type_at_name ON t_action_type(f_kn_id,f_branch,f_name);
+
+
+CREATE TABLE IF NOT EXISTS t_kn_job (
+  f_id VARCHAR(40 CHAR) NOT NULL DEFAULT '',
+  f_name VARCHAR(40 CHAR) NOT NULL DEFAULT '',
+  f_kn_id VARCHAR(40 CHAR) NOT NULL DEFAULT '',
+  f_branch VARCHAR(40 CHAR) NOT NULL DEFAULT '',
+  f_job_type VARCHAR(40 CHAR) NOT NULL DEFAULT '',
+  f_job_concept_config TEXT DEFAULT NULL,
+  f_state VARCHAR(40 CHAR) NOT NULL DEFAULT '',
+  f_state_detail TEXT DEFAULT NULL,
+  f_creator VARCHAR(40 CHAR) NOT NULL DEFAULT '',
+  f_creator_type VARCHAR(20 CHAR) NOT NULL DEFAULT '',
+  f_create_time BIGINT NOT NULL DEFAULT 0,
+  f_finish_time BIGINT NOT NULL DEFAULT 0,
+  f_time_cost BIGINT NOT NULL DEFAULT 0,
+  CLUSTER PRIMARY KEY (f_id)
+);
+
+
+CREATE TABLE IF NOT EXISTS t_kn_task (
+  f_id VARCHAR(40 CHAR) NOT NULL DEFAULT '',
+  f_name VARCHAR(40 CHAR) NOT NULL DEFAULT '',
+  f_job_id VARCHAR(40 CHAR) NOT NULL DEFAULT '',
+  f_concept_type VARCHAR(40 CHAR) NOT NULL DEFAULT '',
+  f_concept_id VARCHAR(40 CHAR) NOT NULL DEFAULT '',
+  f_index VARCHAR(255 CHAR) NOT NULL DEFAULT '',
+  f_doc_count BIGINT NOT NULL DEFAULT 0,
+  f_state VARCHAR(40 CHAR) NOT NULL DEFAULT '',
+  f_state_detail TEXT DEFAULT NULL,
+  f_start_time BIGINT NOT NULL DEFAULT 0,
+  f_finish_time BIGINT NOT NULL DEFAULT 0,
+  f_time_cost BIGINT NOT NULL DEFAULT 0,
+  CLUSTER PRIMARY KEY (f_id)
+);
+
+
+CREATE TABLE IF NOT EXISTS t_concept_group (
+  f_id VARCHAR(40 CHAR) NOT NULL DEFAULT '',
+  f_name VARCHAR(40 CHAR) NOT NULL DEFAULT '',
+  f_tags VARCHAR(255 CHAR) DEFAULT NULL,
+  f_comment VARCHAR(1000 CHAR) NOT NULL DEFAULT '',
+  f_icon VARCHAR(255 CHAR) NOT NULL DEFAULT '',
+  f_color VARCHAR(40 CHAR) NOT NULL DEFAULT '',
+  f_bkn_raw_content TEXT DEFAULT NULL,
+  f_kn_id VARCHAR(40 CHAR) NOT NULL DEFAULT '',
+  f_branch VARCHAR(40 CHAR) NOT NULL DEFAULT '',
+  f_creator VARCHAR(40 CHAR) NOT NULL DEFAULT '',
+  f_creator_type VARCHAR(40 CHAR) NOT NULL DEFAULT '',
+  f_create_time BIGINT NOT NULL DEFAULT 0,
+  f_updater VARCHAR(40 CHAR) NOT NULL DEFAULT '',
+  f_updater_type VARCHAR(40 CHAR) NOT NULL DEFAULT '',
+  f_update_time BIGINT NOT NULL DEFAULT 0,
+  CLUSTER PRIMARY KEY (f_kn_id,f_branch,f_id)
+) ;
+
+CREATE UNIQUE INDEX IF NOT EXISTS uk_concept_group_name ON t_concept_group(f_kn_id,f_branch,f_name);
+
+
+CREATE TABLE IF NOT EXISTS t_concept_group_relation (
+  f_id VARCHAR(40 CHAR) NOT NULL DEFAULT '',
+  f_kn_id VARCHAR(40 CHAR) NOT NULL DEFAULT '',
+  f_branch VARCHAR(40 CHAR) NOT NULL DEFAULT '',
+  f_group_id VARCHAR(40 CHAR) NOT NULL DEFAULT '',
+  f_concept_type VARCHAR(40 CHAR) NOT NULL DEFAULT '',
+  f_concept_id VARCHAR(40 CHAR) NOT NULL DEFAULT '',
+  f_create_time BIGINT NOT NULL DEFAULT 0,
+  CLUSTER PRIMARY KEY (f_id)
+) ;
+
+CREATE UNIQUE INDEX IF NOT EXISTS uk_concept_group_relation ON t_concept_group_relation(f_kn_id,f_branch,f_group_id,f_concept_type,f_concept_id);
+
+
+-- Action Schedule Management
+-- Supports cron-based scheduled action execution with distributed locking
+
+SET SCHEMA adp;
+
+CREATE TABLE IF NOT EXISTS t_action_schedule (
+  f_id VARCHAR(40 CHAR) NOT NULL DEFAULT '',
+  f_name VARCHAR(100 CHAR) NOT NULL DEFAULT '',
+  f_kn_id VARCHAR(40 CHAR) NOT NULL DEFAULT '',
+  f_branch VARCHAR(40 CHAR) NOT NULL DEFAULT '',
+  f_action_type_id VARCHAR(40 CHAR) NOT NULL DEFAULT '',
+  f_cron_expression VARCHAR(100 CHAR) NOT NULL DEFAULT '',
+  f_instance_identities TEXT DEFAULT NULL,
+  f_dynamic_params TEXT DEFAULT NULL,
+  f_status VARCHAR(20 CHAR) NOT NULL DEFAULT 'inactive',
+  f_last_run_time BIGINT NOT NULL DEFAULT 0,
+  f_next_run_time BIGINT NOT NULL DEFAULT 0,
+  f_lock_holder VARCHAR(64 CHAR) DEFAULT NULL,
+  f_lock_time BIGINT NOT NULL DEFAULT 0,
+  f_creator VARCHAR(40 CHAR) NOT NULL DEFAULT '',
+  f_creator_type VARCHAR(20 CHAR) NOT NULL DEFAULT '',
+  f_create_time BIGINT NOT NULL DEFAULT 0,
+  f_updater VARCHAR(40 CHAR) NOT NULL DEFAULT '',
+  f_updater_type VARCHAR(20 CHAR) NOT NULL DEFAULT '',
+  f_update_time BIGINT NOT NULL DEFAULT 0,
+  CLUSTER PRIMARY KEY (f_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_action_schedule_kn_branch ON t_action_schedule(f_kn_id, f_branch);
+CREATE INDEX IF NOT EXISTS idx_action_schedule_status_next_run ON t_action_schedule(f_status, f_next_run_time);
+CREATE INDEX IF NOT EXISTS idx_action_schedule_action_type ON t_action_schedule(f_action_type_id);

--- a/bkn/bkn-backend/migrations/mariadb/0.5.0/pre/01-alter-table.sql
+++ b/bkn/bkn-backend/migrations/mariadb/0.5.0/pre/01-alter-table.sql
@@ -1,0 +1,9 @@
+-- Copyright The kweaver.ai Authors.
+--
+-- Licensed under the Apache License, Version 2.0.
+-- See the LICENSE file in the project root for details.
+
+USE adp;
+
+-- 移除关系类名称唯一性约束，同一 BKN 内允许同名关系类存在
+DROP INDEX IF EXISTS uk_relation_type_name ON adp.t_relation_type;

--- a/bkn/bkn-backend/migrations/mariadb/0.5.0/pre/init.sql
+++ b/bkn/bkn-backend/migrations/mariadb/0.5.0/pre/init.sql
@@ -1,0 +1,221 @@
+-- Copyright The kweaver.ai Authors.
+--
+-- Licensed under the Apache License, Version 2.0.
+-- See the LICENSE file in the project root for details.
+
+USE adp;
+
+-- 业务知识网络
+CREATE TABLE IF NOT EXISTS t_knowledge_network (
+  f_id VARCHAR(40) NOT NULL DEFAULT '' COMMENT '业务知识网络id',
+  f_name VARCHAR(40) NOT NULL DEFAULT '' COMMENT '业务知识网络名称',
+  f_tags VARCHAR(255) DEFAULT NULL COMMENT '标签',
+  f_comment VARCHAR(1000) NOT NULL DEFAULT '' COMMENT '备注',
+  f_icon VARCHAR(255) NOT NULL DEFAULT '' COMMENT '图标',
+  f_color VARCHAR(40) NOT NULL DEFAULT '' COMMENT '颜色',
+  f_bkn_raw_content MEDIUMTEXT DEFAULT NULL COMMENT 'BKNRawContent',
+  f_branch VARCHAR(40) NOT NULL DEFAULT '' COMMENT '分支',
+  f_business_domain VARCHAR(40) NOT NULL DEFAULT '' COMMENT '业务域',
+  f_creator VARCHAR(40) NOT NULL DEFAULT '' COMMENT '创建者id',
+  f_creator_type VARCHAR(20) NOT NULL DEFAULT '' COMMENT '创建者类型',
+  f_create_time BIGINT(20) NOT NULL DEFAULT 0 COMMENT '创建时间',
+  f_updater VARCHAR(40) NOT NULL DEFAULT '' COMMENT '更新者id',
+  f_updater_type VARCHAR(20) NOT NULL DEFAULT '' COMMENT '更新者类型',
+  f_update_time BIGINT(20) NOT NULL DEFAULT 0 COMMENT '更新时间',
+  PRIMARY KEY (f_id,f_branch),
+  UNIQUE KEY uk_kn_name (f_name,f_branch)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_bin COMMENT = '业务知识网络';
+
+-- 对象类
+CREATE TABLE IF NOT EXISTS t_object_type (
+  f_id VARCHAR(40) NOT NULL DEFAULT '' COMMENT '对象类id',
+  f_name VARCHAR(40) NOT NULL DEFAULT '' COMMENT '对象类名称',
+  f_tags VARCHAR(255) DEFAULT NULL COMMENT '标签',
+  f_comment VARCHAR(1000) NOT NULL DEFAULT '' COMMENT '备注', 
+  f_icon VARCHAR(255) NOT NULL DEFAULT '' COMMENT '图标',
+  f_color VARCHAR(40) NOT NULL DEFAULT '' COMMENT '颜色',
+  f_bkn_raw_content MEDIUMTEXT DEFAULT NULL COMMENT 'BKNRawContent',
+  f_kn_id VARCHAR(40) NOT NULL DEFAULT '' COMMENT '业务知识网络id',
+  f_branch VARCHAR(40) NOT NULL DEFAULT '' COMMENT '分支',
+  f_data_source VARCHAR(255) NOT NULL COMMENT '数据来源，当前只有视图',
+  f_data_properties LONGTEXT DEFAULT NULL COMMENT '数据属性',
+  f_logic_properties MEDIUMTEXT DEFAULT NULL COMMENT '逻辑属性',
+  f_primary_keys VARCHAR(8192) DEFAULT NULL COMMENT '对象类主键',
+  f_display_key VARCHAR(40) NOT NULL DEFAULT '' COMMENT '对象实例的显示属性',
+  f_incremental_key VARCHAR(40) NOT NULL DEFAULT '' COMMENT '对象类增量键',
+  f_creator VARCHAR(40) NOT NULL DEFAULT '' COMMENT '创建者id',
+  f_creator_type VARCHAR(20) NOT NULL DEFAULT '' COMMENT '创建者类型',
+  f_create_time BIGINT(20) NOT NULL DEFAULT 0 COMMENT '创建时间',
+  f_updater VARCHAR(40) NOT NULL DEFAULT '' COMMENT '更新者id',
+  f_updater_type VARCHAR(20) NOT NULL DEFAULT '' COMMENT '更新者类型',
+  f_update_time BIGINT(20) NOT NULL DEFAULT 0 COMMENT '更新时间',
+  PRIMARY KEY (f_kn_id,f_branch,f_id),
+  UNIQUE KEY uk_object_type_name (f_kn_id,f_branch,f_name)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_bin COMMENT = '对象类';
+
+-- 对象类状态
+CREATE TABLE IF NOT EXISTS t_object_type_status (
+  f_id VARCHAR(40) NOT NULL DEFAULT '' COMMENT '对象类id',
+  f_kn_id VARCHAR(40) NOT NULL DEFAULT '' COMMENT '业务知识网络id',
+  f_branch VARCHAR(40) NOT NULL DEFAULT '' COMMENT '分支',
+  f_incremental_key VARCHAR(40) NOT NULL DEFAULT '' COMMENT '对象类增量键',
+  f_incremental_value VARCHAR(40) NOT NULL DEFAULT '' COMMENT '对象类当前增量值',
+  f_index VARCHAR(255) NOT NULL DEFAULT '' COMMENT '索引名称',
+  f_index_available BOOLEAN NOT NULL DEFAULT 0 COMMENT '索引是否可用',
+  f_doc_count BIGINT(20) NOT NULL DEFAULT 0 COMMENT '文档数量',
+  f_storage_size BIGINT(20) NOT NULL DEFAULT 0 COMMENT '存储大小',
+  f_update_time BIGINT(20) NOT NULL DEFAULT 0 COMMENT '更新时间',
+  PRIMARY KEY (f_kn_id,f_branch,f_id)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_bin COMMENT = '对象类状态';
+
+-- 关系类
+CREATE TABLE IF NOT EXISTS t_relation_type (
+  f_id VARCHAR(40) NOT NULL DEFAULT '' COMMENT '关系类id',
+  f_name VARCHAR(40) NOT NULL DEFAULT '' COMMENT '关系类名称',
+  f_tags VARCHAR(255) DEFAULT NULL COMMENT '标签',
+  f_comment VARCHAR(1000) NOT NULL DEFAULT '' COMMENT '备注', 
+  f_icon VARCHAR(255) NOT NULL DEFAULT '' COMMENT '图标',
+  f_color VARCHAR(40) NOT NULL DEFAULT '' COMMENT '颜色',
+  f_bkn_raw_content MEDIUMTEXT DEFAULT NULL COMMENT 'BKNRawContent',
+  f_kn_id VARCHAR(40) NOT NULL DEFAULT '' COMMENT '业务知识网络id',
+  f_branch VARCHAR(40) NOT NULL DEFAULT '' COMMENT '分支',
+  f_source_object_type_id VARCHAR(40) NOT NULL DEFAULT '' COMMENT '起点对象类',
+  f_target_object_type_id VARCHAR(40) NOT NULL DEFAULT '' COMMENT '终点对象类',
+  f_type VARCHAR(40) NOT NULL DEFAULT '' COMMENT '关联类型',
+  f_mapping_rules TEXT DEFAULT NULL COMMENT '关联规则',
+  f_creator VARCHAR(40) NOT NULL DEFAULT '' COMMENT '创建者id',
+  f_creator_type VARCHAR(20) NOT NULL DEFAULT '' COMMENT '创建者类型',
+  f_create_time BIGINT(20) NOT NULL DEFAULT 0 COMMENT '创建时间',
+  f_updater VARCHAR(40) NOT NULL DEFAULT '' COMMENT '更新者id',
+  f_updater_type VARCHAR(20) NOT NULL DEFAULT '' COMMENT '更新者类型',
+  f_update_time BIGINT(20) NOT NULL DEFAULT 0 COMMENT '更新时间',
+  PRIMARY KEY (f_kn_id,f_branch,f_id)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_bin COMMENT = '关系类';
+
+-- 行动类
+CREATE TABLE IF NOT EXISTS t_action_type (
+  f_id VARCHAR(40) NOT NULL DEFAULT '' COMMENT '行动类id',
+  f_name VARCHAR(40) NOT NULL DEFAULT '' COMMENT '行动类名称',
+  f_tags VARCHAR(255) DEFAULT NULL COMMENT '标签',
+  f_comment VARCHAR(1000) NOT NULL DEFAULT '' COMMENT '备注', 
+  f_icon VARCHAR(255) NOT NULL DEFAULT '' COMMENT '图标',
+  f_color VARCHAR(40) NOT NULL DEFAULT '' COMMENT '颜色',
+  f_bkn_raw_content MEDIUMTEXT DEFAULT NULL COMMENT 'BKNRawContent',
+  f_kn_id VARCHAR(40) NOT NULL DEFAULT '' COMMENT '业务知识网络id',
+  f_branch VARCHAR(40) NOT NULL DEFAULT '' COMMENT '分支',
+  f_action_type VARCHAR(40) NOT NULL DEFAULT '' COMMENT '行动类型',
+  f_object_type_id VARCHAR(40) NOT NULL DEFAULT '' COMMENT '对象类',
+  f_condition TEXT DEFAULT NULL COMMENT '行动条件',
+  f_affect TEXT DEFAULT NULL COMMENT '行动影响',
+  f_action_source VARCHAR(255) NOT NULL COMMENT '行动资源',
+  f_parameters TEXT DEFAULT NULL COMMENT '行动参数',
+  f_schedule VARCHAR(255) DEFAULT NULL COMMENT '行动监听',
+  f_creator VARCHAR(40) NOT NULL DEFAULT '' COMMENT '创建者id',
+  f_creator_type VARCHAR(20) NOT NULL DEFAULT '' COMMENT '创建者类型',
+  f_create_time BIGINT(20) NOT NULL DEFAULT 0 COMMENT '创建时间',
+  f_updater VARCHAR(40) NOT NULL DEFAULT '' COMMENT '更新者id',
+  f_updater_type VARCHAR(20) NOT NULL DEFAULT '' COMMENT '更新者类型',
+  f_update_time BIGINT(20) NOT NULL DEFAULT 0 COMMENT '更新时间',
+  PRIMARY KEY (f_kn_id,f_branch,f_id),
+  UNIQUE KEY uk_action_type_name (f_kn_id,f_branch,f_name)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_bin COMMENT = '行动类';
+
+
+-- 任务管理
+CREATE TABLE IF NOT EXISTS t_kn_job (
+  f_id VARCHAR(40) NOT NULL DEFAULT '' COMMENT '任务id',
+  f_name VARCHAR(40) NOT NULL DEFAULT '' COMMENT '任务名称',
+  f_kn_id VARCHAR(40) NOT NULL DEFAULT '' COMMENT '业务知识网络id',
+  f_branch VARCHAR(40) NOT NULL DEFAULT '' COMMENT '分支',
+  f_job_type VARCHAR(40) NOT NULL DEFAULT '' COMMENT '任务类型',
+  f_job_concept_config MEDIUMTEXT DEFAULT NULL COMMENT '任务概念配置',
+  f_state VARCHAR(40) NOT NULL DEFAULT '' COMMENT '状态',
+  f_state_detail TEXT DEFAULT NULL COMMENT '状态详情',
+  f_creator VARCHAR(40) NOT NULL DEFAULT '' COMMENT '创建者id',
+  f_creator_type VARCHAR(20) NOT NULL DEFAULT '' COMMENT '创建者类型',
+  f_create_time BIGINT(20) NOT NULL DEFAULT 0 COMMENT '创建时间',
+  f_finish_time BIGINT(20) NOT NULL DEFAULT 0 COMMENT '完成时间',
+  f_time_cost BIGINT(20) NOT NULL DEFAULT 0 COMMENT '耗时',
+  PRIMARY KEY (f_id)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_bin COMMENT = '任务';
+
+
+-- 子任务管理
+CREATE TABLE IF NOT EXISTS t_kn_task (
+  f_id VARCHAR(40) NOT NULL DEFAULT '' COMMENT '子任务id',
+  f_name VARCHAR(40) NOT NULL DEFAULT '' COMMENT '子任务名称',
+  f_job_id VARCHAR(40) NOT NULL DEFAULT '' COMMENT '任务id',
+  f_concept_type VARCHAR(40) NOT NULL DEFAULT '' COMMENT '概念类型',
+  f_concept_id VARCHAR(40) NOT NULL DEFAULT '' COMMENT '概念id',
+  f_index VARCHAR(255) NOT NULL DEFAULT '' COMMENT '索引名称',
+  f_doc_count BIGINT(20) NOT NULL DEFAULT 0 COMMENT '文档数量',
+  f_state VARCHAR(40) NOT NULL DEFAULT '' COMMENT '状态',
+  f_state_detail TEXT DEFAULT NULL COMMENT '状态详情',
+  f_start_time BIGINT(20) NOT NULL DEFAULT 0 COMMENT '开始时间',
+  f_finish_time BIGINT(20) NOT NULL DEFAULT 0 COMMENT '完成时间',
+  f_time_cost BIGINT(20) NOT NULL DEFAULT 0 COMMENT '耗时',
+  PRIMARY KEY (f_id)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_bin COMMENT = '子任务';
+
+-- 概念分组
+CREATE TABLE IF NOT EXISTS t_concept_group (
+  f_id VARCHAR(40) NOT NULL DEFAULT '' COMMENT '概念分组id',
+  f_name VARCHAR(40) NOT NULL DEFAULT '' COMMENT '概念分组名称',
+  f_tags VARCHAR(255) DEFAULT NULL COMMENT '标签',
+  f_comment VARCHAR(1000) NOT NULL DEFAULT '' COMMENT '备注',
+  f_icon VARCHAR(255) NOT NULL DEFAULT '' COMMENT '图标',
+  f_color VARCHAR(40) NOT NULL DEFAULT '' COMMENT '颜色',
+  f_bkn_raw_content MEDIUMTEXT DEFAULT NULL COMMENT 'BKNRawContent',
+  f_kn_id VARCHAR(40) NOT NULL DEFAULT '' COMMENT '业务知识网络id',
+  f_branch VARCHAR(40) NOT NULL DEFAULT '' COMMENT '分支',
+  f_creator VARCHAR(40) NOT NULL DEFAULT '' COMMENT '创建者id',
+  f_creator_type VARCHAR(20) NOT NULL DEFAULT '' COMMENT '创建者类型',
+  f_create_time BIGINT(20) NOT NULL DEFAULT 0 COMMENT '创建时间',
+  f_updater VARCHAR(40) NOT NULL DEFAULT '' COMMENT '更新者id',
+  f_updater_type VARCHAR(20) NOT NULL DEFAULT '' COMMENT '更新者类型',
+  f_update_time BIGINT(20) NOT NULL DEFAULT 0 COMMENT '更新时间',
+  PRIMARY KEY (f_kn_id,f_branch,f_id),
+  UNIQUE KEY uk_concept_group_name (f_kn_id,f_branch,f_name)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_bin COMMENT = '概念分组';
+ 
+-- 分组与概念对应表
+CREATE TABLE IF NOT EXISTS t_concept_group_relation (
+  f_id VARCHAR(40) NOT NULL DEFAULT '' COMMENT '主键id',
+  f_kn_id VARCHAR(40) NOT NULL DEFAULT '' COMMENT '业务知识网络id',
+  f_branch VARCHAR(40) NOT NULL DEFAULT '' COMMENT '分支',
+  f_group_id VARCHAR(40) NOT NULL DEFAULT '' COMMENT '概念分组id',
+  f_concept_type VARCHAR(40) NOT NULL DEFAULT '' COMMENT '概念类型',
+  f_concept_id VARCHAR(40) NOT NULL DEFAULT '' COMMENT '概念id',
+  f_create_time BIGINT(20) NOT NULL DEFAULT 0 COMMENT '创建时间',
+  PRIMARY KEY (f_id),
+  UNIQUE KEY uk_concept_group_relation (f_kn_id,f_branch,f_group_id,f_concept_type,f_concept_id)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_bin COMMENT = '分组与概念对应表';
+
+-- Action Schedule Management
+-- Supports cron-based scheduled action execution with distributed locking
+
+CREATE TABLE IF NOT EXISTS t_action_schedule (
+  f_id VARCHAR(40) NOT NULL DEFAULT '' COMMENT 'Schedule ID',
+  f_name VARCHAR(100) NOT NULL DEFAULT '' COMMENT 'Schedule name',
+  f_kn_id VARCHAR(40) NOT NULL DEFAULT '' COMMENT 'Knowledge network ID',
+  f_branch VARCHAR(40) NOT NULL DEFAULT '' COMMENT 'Branch',
+  f_action_type_id VARCHAR(40) NOT NULL DEFAULT '' COMMENT 'Action type ID to execute',
+  f_cron_expression VARCHAR(100) NOT NULL DEFAULT '' COMMENT 'Standard 5-field cron expression (min hour dom mon dow)',
+  f_instance_identities MEDIUMTEXT DEFAULT NULL COMMENT 'JSON array of target object instance identities',
+  f_dynamic_params MEDIUMTEXT DEFAULT NULL COMMENT 'JSON object of dynamic parameters',
+  f_status VARCHAR(20) NOT NULL DEFAULT 'inactive' COMMENT 'Schedule status: active or inactive',
+  f_last_run_time BIGINT(20) NOT NULL DEFAULT 0 COMMENT 'Last execution timestamp (ms)',
+  f_next_run_time BIGINT(20) NOT NULL DEFAULT 0 COMMENT 'Next scheduled run timestamp (ms)',
+  f_lock_holder VARCHAR(64) DEFAULT NULL COMMENT 'Pod ID holding execution lock (NULL = unlocked)',
+  f_lock_time BIGINT(20) NOT NULL DEFAULT 0 COMMENT 'Lock acquisition timestamp (ms) for timeout detection',
+  f_creator VARCHAR(40) NOT NULL DEFAULT '' COMMENT 'Creator ID',
+  f_creator_type VARCHAR(20) NOT NULL DEFAULT '' COMMENT 'Creator type',
+  f_create_time BIGINT(20) NOT NULL DEFAULT 0 COMMENT 'Create timestamp (ms)',
+  f_updater VARCHAR(40) NOT NULL DEFAULT '' COMMENT 'Updater ID',
+  f_updater_type VARCHAR(20) NOT NULL DEFAULT '' COMMENT 'Updater type',
+  f_update_time BIGINT(20) NOT NULL DEFAULT 0 COMMENT 'Update timestamp (ms)',
+  PRIMARY KEY (f_id),
+  KEY idx_kn_branch (f_kn_id, f_branch),
+  KEY idx_status_next_run (f_status, f_next_run_time),
+  KEY idx_action_type (f_action_type_id)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_bin COMMENT = 'Action schedule for cron-based execution';

--- a/bkn/bkn-backend/server/drivenadapters/relation_type/relation_type_access.go
+++ b/bkn/bkn-backend/server/drivenadapters/relation_type/relation_type_access.go
@@ -95,53 +95,6 @@ func (rta *relationTypeAccess) CheckRelationTypeExistByID(ctx context.Context, k
 	return name, true, nil
 }
 
-// 根据名称获取关系类存在性
-func (rta *relationTypeAccess) CheckRelationTypeExistByName(ctx context.Context, knID string, branch string, rtName string) (string, bool, error) {
-	ctx, span := ar_trace.Tracer.Start(ctx, "CheckRelationTypeExistByName", trace.WithSpanKind(trace.SpanKindClient))
-	defer span.End()
-
-	span.SetAttributes(
-		attr.Key("db_url").String(libdb.GetDBUrl()),
-		attr.Key("db_type").String(libdb.GetDBType()),
-	)
-
-	//查询
-	sqlStr, vals, err := sq.Select(
-		"f_id").
-		From(RT_TABLE_NAME).
-		Where(sq.Eq{"f_kn_id": knID}).
-		Where(sq.Eq{"f_branch": branch}).
-		Where(sq.Eq{"f_name": rtName}).
-		ToSql()
-	if err != nil {
-		logger.Errorf("Failed to build the sql of get id by name, error: %s", err.Error())
-		o11y.Error(ctx, fmt.Sprintf("Failed to build the sql of get id by name, error: %s", err.Error()))
-		span.SetStatus(codes.Error, "Build sql failed ")
-		return "", false, err
-	}
-
-	// 记录处理的 sql 字符串
-	o11y.Info(ctx, fmt.Sprintf("获取关系类信息的 sql 语句: %s", sqlStr))
-
-	var rtID string
-	err = rta.db.QueryRow(sqlStr, vals...).Scan(
-		&rtID,
-	)
-	if err == sql.ErrNoRows {
-		span.SetAttributes(attr.Key("no_rows").Bool(true))
-		span.SetStatus(codes.Ok, "")
-		return "", false, nil
-	} else if err != nil {
-		logger.Errorf("row scan failed, err: %v\n", err)
-		o11y.Error(ctx, fmt.Sprintf("Row scan failed, err: %v", err))
-		span.SetStatus(codes.Error, "Row scan failed ")
-		return "", false, err
-	}
-
-	span.SetStatus(codes.Ok, "")
-	return rtID, true, nil
-}
-
 // 创建关系类
 func (rta *relationTypeAccess) CreateRelationType(ctx context.Context, tx *sql.Tx, relationType *interfaces.RelationType) error {
 	ctx, span := ar_trace.Tracer.Start(ctx, "CreateRelationType", trace.WithSpanKind(trace.SpanKindClient))

--- a/bkn/bkn-backend/server/drivenadapters/relation_type/relation_type_access_test.go
+++ b/bkn/bkn-backend/server/drivenadapters/relation_type/relation_type_access_test.go
@@ -123,60 +123,6 @@ func Test_relationTypeAccess_CheckRelationTypeExistByID(t *testing.T) {
 	})
 }
 
-func Test_relationTypeAccess_CheckRelationTypeExistByName(t *testing.T) {
-	Convey("test CheckRelationTypeExistByName\n", t, func() {
-		appSetting := &common.AppSetting{}
-		rta, smock := MockNewRelationTypeAccess(appSetting)
-
-		sqlStr := "SELECT f_id FROM t_relation_type WHERE f_kn_id = ? AND f_branch = ? AND f_name = ?"
-
-		knID := "kn1"
-		branch := "main"
-		rtName := "Relation Type 1"
-
-		Convey("CheckRelationTypeExistByName Success \n", func() {
-			rows := sqlmock.NewRows([]string{"f_id"}).AddRow("rt1")
-			smock.ExpectQuery(sqlStr).WithArgs(knID, branch, rtName).WillReturnRows(rows)
-
-			rtID, exists, err := rta.CheckRelationTypeExistByName(testCtx, knID, branch, rtName)
-			So(err, ShouldBeNil)
-			So(exists, ShouldBeTrue)
-			So(rtID, ShouldEqual, "rt1")
-
-			if err := smock.ExpectationsWereMet(); err != nil {
-				t.Errorf("there were unfulfilled expectations: %s", err)
-			}
-		})
-
-		Convey("CheckRelationTypeExistByName Success no row \n", func() {
-			smock.ExpectQuery(sqlStr).WithArgs(knID, branch, rtName).WillReturnError(sql.ErrNoRows)
-
-			rtID, exists, err := rta.CheckRelationTypeExistByName(testCtx, knID, branch, rtName)
-			So(rtID, ShouldEqual, "")
-			So(exists, ShouldBeFalse)
-			So(err, ShouldBeNil)
-
-			if err := smock.ExpectationsWereMet(); err != nil {
-				t.Errorf("there were unfulfilled expectations: %s", err)
-			}
-		})
-
-		Convey("CheckRelationTypeExistByName Failed \n", func() {
-			expectedErr := errors.New("some error")
-			smock.ExpectQuery(sqlStr).WithArgs(knID, branch, rtName).WillReturnError(expectedErr)
-
-			rtID, exists, err := rta.CheckRelationTypeExistByName(testCtx, knID, branch, rtName)
-			So(rtID, ShouldEqual, "")
-			So(exists, ShouldBeFalse)
-			So(err, ShouldResemble, expectedErr)
-
-			if err := smock.ExpectationsWereMet(); err != nil {
-				t.Errorf("there were unfulfilled expectations: %s", err)
-			}
-		})
-	})
-}
-
 func Test_relationTypeAccess_CreateRelationType(t *testing.T) {
 	Convey("test CreateRelationType\n", t, func() {
 		appSetting := &common.AppSetting{}

--- a/bkn/bkn-backend/server/driveradapters/relation_type_handler.go
+++ b/bkn/bkn-backend/server/driveradapters/relation_type_handler.go
@@ -291,7 +291,7 @@ func (r *restHandler) UpdateRelationType(c *gin.Context, visitor hydra.Visitor) 
 	o11y.Info(ctx, fmt.Sprintf("修改关系类请求参数: [%s, %v]", c.Request.RequestURI, relationType))
 
 	// 先按id获取原对象
-	oldRTName, exist, err := r.rts.CheckRelationTypeExistByID(ctx, knID, branch, rtID)
+	_, exist, err = r.rts.CheckRelationTypeExistByID(ctx, knID, branch, rtID)
 	if err != nil {
 		httpErr := err.(*rest.HTTPError)
 
@@ -327,30 +327,6 @@ func (r *restHandler) UpdateRelationType(c *gin.Context, visitor hydra.Visitor) 
 		return
 	}
 
-	// 名称或分组不同，校验新名称是否已存在
-	ifNameModify := false
-	if oldRTName != relationType.RTName {
-		ifNameModify = true
-		_, exist, err = r.rts.CheckRelationTypeExistByName(ctx, knID, branch, relationType.RTName)
-		if err != nil {
-			httpErr := err.(*rest.HTTPError)
-
-			// 设置 trace 的错误信息的 attributes
-			o11y.AddHttpAttrs4HttpError(span, httpErr)
-			rest.ReplyError(c, httpErr)
-			return
-		}
-		if exist {
-			httpErr := rest.NewHTTPError(ctx, http.StatusForbidden,
-				berrors.BknBackend_RelationType_RelationTypeNameExisted)
-
-			// 设置 trace 的错误信息的 attributes
-			o11y.AddHttpAttrs4HttpError(span, httpErr)
-			rest.ReplyError(c, httpErr)
-			return
-		}
-	}
-	relationType.IfNameModify = ifNameModify
 	relationType.KNID = knID
 
 	//根据id修改信息

--- a/bkn/bkn-backend/server/driveradapters/relation_type_handler_test.go
+++ b/bkn/bkn-backend/server/driveradapters/relation_type_handler_test.go
@@ -235,7 +235,6 @@ func Test_RelationTypeRestHandler_UpdateRelationType(t *testing.T) {
 		Convey("Success UpdateRelationType\n", func() {
 			kns.EXPECT().CheckKNExistByID(gomock.Any(), knID, gomock.Any()).Return(knID, true, nil)
 			rts.EXPECT().CheckRelationTypeExistByID(gomock.Any(), knID, gomock.Any(), rtID).Return("relation2", true, nil)
-			rts.EXPECT().CheckRelationTypeExistByName(gomock.Any(), knID, gomock.Any(), relationType.RTName).Return("", false, nil)
 			rts.EXPECT().UpdateRelationType(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 
 			reqParamByte, _ := sonic.Marshal(relationType)
@@ -283,10 +282,10 @@ func Test_RelationTypeRestHandler_UpdateRelationType(t *testing.T) {
 			So(w.Result().StatusCode, ShouldEqual, http.StatusForbidden)
 		})
 
-		Convey("RelationType name already exists\n", func() {
+		Convey("Update to existing name succeeds (no name uniqueness check)\n", func() {
 			kns.EXPECT().CheckKNExistByID(gomock.Any(), knID, gomock.Any()).Return(knID, true, nil)
 			rts.EXPECT().CheckRelationTypeExistByID(gomock.Any(), knID, gomock.Any(), rtID).Return("oldname", true, nil)
-			rts.EXPECT().CheckRelationTypeExistByName(gomock.Any(), knID, gomock.Any(), relationType.RTName).Return("relation1", true, nil)
+			rts.EXPECT().UpdateRelationType(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 
 			reqParamByte, _ := sonic.Marshal(relationType)
 			req := httptest.NewRequest(http.MethodPut, url, bytes.NewReader(reqParamByte))
@@ -294,7 +293,7 @@ func Test_RelationTypeRestHandler_UpdateRelationType(t *testing.T) {
 			w := httptest.NewRecorder()
 			engine.ServeHTTP(w, req)
 
-			So(w.Result().StatusCode, ShouldEqual, http.StatusForbidden)
+			So(w.Result().StatusCode, ShouldEqual, http.StatusNoContent)
 		})
 
 		Convey("UpdateRelationType failed\n", func() {
@@ -308,7 +307,6 @@ func Test_RelationTypeRestHandler_UpdateRelationType(t *testing.T) {
 
 			kns.EXPECT().CheckKNExistByID(gomock.Any(), knID, gomock.Any()).Return(knID, true, nil)
 			rts.EXPECT().CheckRelationTypeExistByID(gomock.Any(), knID, gomock.Any(), rtID).Return("relation2", true, nil)
-			rts.EXPECT().CheckRelationTypeExistByName(gomock.Any(), knID, gomock.Any(), relationType.RTName).Return("", false, nil)
 			rts.EXPECT().UpdateRelationType(gomock.Any(), gomock.Any(), gomock.Any()).Return(err)
 
 			reqParamByte, _ := sonic.Marshal(relationType)
@@ -832,7 +830,6 @@ func Test_RelationTypeRestHandler_UpdateRelationTypeByIn(t *testing.T) {
 		Convey("Success\n", func() {
 			kns.EXPECT().CheckKNExistByID(gomock.Any(), knID, gomock.Any()).Return(knID, true, nil)
 			rts.EXPECT().CheckRelationTypeExistByID(gomock.Any(), knID, gomock.Any(), rtID).Return("old_relation1", true, nil)
-			rts.EXPECT().CheckRelationTypeExistByName(gomock.Any(), knID, gomock.Any(), relationType.RTName).Return("", false, nil)
 			rts.EXPECT().UpdateRelationType(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 
 			urlIn := "/api/bkn-backend/in/v1/knowledge-networks/" + knID + "/relation-types/" + rtID

--- a/bkn/bkn-backend/server/driveradapters/validate_relation_type.go
+++ b/bkn/bkn-backend/server/driveradapters/validate_relation_type.go
@@ -20,7 +20,6 @@ import (
 )
 
 func ValidateRelationTypes(ctx context.Context, knID string, relationTypes []*interfaces.RelationType) error {
-	tmpNameMap := make(map[string]any)
 	idMap := make(map[string]any)
 	for i := 0; i < len(relationTypes); i++ {
 		// 校验导入模型时模块是否是关系类
@@ -46,12 +45,6 @@ func ValidateRelationTypes(ctx context.Context, knID string, relationTypes []*in
 			return err
 		}
 
-		// 3. 校验 请求体中关系类名称重复性
-		if _, ok := tmpNameMap[relationTypes[i].RTName]; !ok {
-			tmpNameMap[relationTypes[i].RTName] = nil
-		} else {
-			return rest.NewHTTPError(ctx, http.StatusBadRequest, berrors.BknBackend_RelationType_Duplicated_Name)
-		}
 		relationTypes[i].KNID = knID
 	}
 	return nil

--- a/bkn/bkn-backend/server/driveradapters/validate_relation_type_test.go
+++ b/bkn/bkn-backend/server/driveradapters/validate_relation_type_test.go
@@ -455,3 +455,60 @@ func Test_ValidateRelationType(t *testing.T) {
 		})
 	})
 }
+
+func Test_ValidateRelationTypes(t *testing.T) {
+	Convey("Test ValidateRelationTypes\n", t, func() {
+		ctx := context.Background()
+		knID := "kn1"
+
+		makeRT := func(id, name string) *interfaces.RelationType {
+			return &interfaces.RelationType{
+				RelationTypeWithKeyField: interfaces.RelationTypeWithKeyField{
+					RTID:               id,
+					RTName:             name,
+					SourceObjectTypeID: "ot1",
+					TargetObjectTypeID: "ot2",
+					Type:               interfaces.RELATION_TYPE_DIRECT,
+					MappingRules: []interfaces.Mapping{
+						{
+							SourceProp: interfaces.SimpleProperty{Name: "prop1"},
+							TargetProp: interfaces.SimpleProperty{Name: "prop2"},
+						},
+					},
+				},
+			}
+		}
+
+		Convey("Success with two relation types having the same name\n", func() {
+			relationTypes := []*interfaces.RelationType{
+				makeRT("rt1", "same_name"),
+				makeRT("rt2", "same_name"),
+			}
+			err := ValidateRelationTypes(ctx, knID, relationTypes)
+			So(err, ShouldBeNil)
+			So(relationTypes[0].KNID, ShouldEqual, knID)
+			So(relationTypes[1].KNID, ShouldEqual, knID)
+		})
+
+		Convey("Failed when two relation types have the same ID\n", func() {
+			relationTypes := []*interfaces.RelationType{
+				makeRT("rt1", "name1"),
+				makeRT("rt1", "name2"),
+			}
+			err := ValidateRelationTypes(ctx, knID, relationTypes)
+			So(err, ShouldNotBeNil)
+			httpErr := err.(*rest.HTTPError)
+			So(httpErr.BaseError.ErrorCode, ShouldEqual, berrors.BknBackend_RelationType_Duplicated_IDInFile)
+		})
+
+		Convey("Success with multiple distinct relation types\n", func() {
+			relationTypes := []*interfaces.RelationType{
+				makeRT("rt1", "name1"),
+				makeRT("rt2", "name2"),
+				makeRT("rt3", "name1"),
+			}
+			err := ValidateRelationTypes(ctx, knID, relationTypes)
+			So(err, ShouldBeNil)
+		})
+	})
+}

--- a/bkn/bkn-backend/server/errors/relation_type.go
+++ b/bkn/bkn-backend/server/errors/relation_type.go
@@ -9,11 +9,9 @@ package errors
 const (
 	// 400
 	BknBackend_RelationType_Duplicated_IDInFile               = "BknBackend.RelationType.Duplicated.IDInFile"
-	BknBackend_RelationType_Duplicated_Name                   = "BknBackend.RelationType.Duplicated.Name"
 	BknBackend_RelationType_InvalidParameter                  = "BknBackend.RelationType.InvalidParameter"
 	BknBackend_RelationType_InvalidParameter_ConceptCondition = "BknBackend.RelationType.InvalidParameter.ConceptCondition"
 	BknBackend_RelationType_RelationTypeIDExisted             = "BknBackend.RelationType.RelationTypeIDExisted"
-	BknBackend_RelationType_RelationTypeNameExisted           = "BknBackend.RelationType.RelationTypeNameExisted"
 	BknBackend_RelationType_LengthExceeded_Name               = "BknBackend.RelationType.LengthExceeded.Name"
 	BknBackend_RelationType_NullParameter_Name                = "BknBackend.RelationType.NullParameter.Name"
 
@@ -32,11 +30,9 @@ var (
 	RelationTypeErrCodeList = []string{
 		// 400
 		BknBackend_RelationType_Duplicated_IDInFile,
-		BknBackend_RelationType_Duplicated_Name,
 		BknBackend_RelationType_InvalidParameter,
 		BknBackend_RelationType_InvalidParameter_ConceptCondition,
 		BknBackend_RelationType_RelationTypeIDExisted,
-		BknBackend_RelationType_RelationTypeNameExisted,
 		BknBackend_RelationType_LengthExceeded_Name,
 		BknBackend_RelationType_NullParameter_Name,
 

--- a/bkn/bkn-backend/server/interfaces/mock/mock_relation_type_access.go
+++ b/bkn/bkn-backend/server/interfaces/mock/mock_relation_type_access.go
@@ -58,22 +58,6 @@ func (mr *MockRelationTypeAccessMockRecorder) CheckRelationTypeExistByID(ctx, kn
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckRelationTypeExistByID", reflect.TypeOf((*MockRelationTypeAccess)(nil).CheckRelationTypeExistByID), ctx, knID, branch, rtID)
 }
 
-// CheckRelationTypeExistByName mocks base method.
-func (m *MockRelationTypeAccess) CheckRelationTypeExistByName(ctx context.Context, knID, branch, rtName string) (string, bool, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CheckRelationTypeExistByName", ctx, knID, branch, rtName)
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(bool)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
-}
-
-// CheckRelationTypeExistByName indicates an expected call of CheckRelationTypeExistByName.
-func (mr *MockRelationTypeAccessMockRecorder) CheckRelationTypeExistByName(ctx, knID, branch, rtName any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckRelationTypeExistByName", reflect.TypeOf((*MockRelationTypeAccess)(nil).CheckRelationTypeExistByName), ctx, knID, branch, rtName)
-}
-
 // CreateRelationType mocks base method.
 func (m *MockRelationTypeAccess) CreateRelationType(ctx context.Context, tx *sql.Tx, relationType *interfaces.RelationType) error {
 	m.ctrl.T.Helper()

--- a/bkn/bkn-backend/server/interfaces/mock/mock_relation_type_service.go
+++ b/bkn/bkn-backend/server/interfaces/mock/mock_relation_type_service.go
@@ -58,22 +58,6 @@ func (mr *MockRelationTypeServiceMockRecorder) CheckRelationTypeExistByID(ctx, k
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckRelationTypeExistByID", reflect.TypeOf((*MockRelationTypeService)(nil).CheckRelationTypeExistByID), ctx, knID, branch, rtID)
 }
 
-// CheckRelationTypeExistByName mocks base method.
-func (m *MockRelationTypeService) CheckRelationTypeExistByName(ctx context.Context, knID, branch, rtName string) (string, bool, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CheckRelationTypeExistByName", ctx, knID, branch, rtName)
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(bool)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
-}
-
-// CheckRelationTypeExistByName indicates an expected call of CheckRelationTypeExistByName.
-func (mr *MockRelationTypeServiceMockRecorder) CheckRelationTypeExistByName(ctx, knID, branch, rtName any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckRelationTypeExistByName", reflect.TypeOf((*MockRelationTypeService)(nil).CheckRelationTypeExistByName), ctx, knID, branch, rtName)
-}
-
 // CreateRelationTypes mocks base method.
 func (m *MockRelationTypeService) CreateRelationTypes(ctx context.Context, tx *sql.Tx, relationTypes []*interfaces.RelationType, mode string, validateDependency bool) ([]string, error) {
 	m.ctrl.T.Helper()

--- a/bkn/bkn-backend/server/interfaces/relation_type_access.go
+++ b/bkn/bkn-backend/server/interfaces/relation_type_access.go
@@ -13,7 +13,6 @@ import (
 //go:generate mockgen -source ../interfaces/relation_type_access.go -destination ../interfaces/mock/mock_relation_type_access.go
 type RelationTypeAccess interface {
 	CheckRelationTypeExistByID(ctx context.Context, knID string, branch string, rtID string) (string, bool, error)
-	CheckRelationTypeExistByName(ctx context.Context, knID string, branch string, rtName string) (string, bool, error)
 
 	CreateRelationType(ctx context.Context, tx *sql.Tx, relationType *RelationType) error
 	ListRelationTypes(ctx context.Context, query RelationTypesQueryParams) ([]*RelationType, error)

--- a/bkn/bkn-backend/server/interfaces/relation_type_service.go
+++ b/bkn/bkn-backend/server/interfaces/relation_type_service.go
@@ -13,7 +13,6 @@ import (
 //go:generate mockgen -source ../interfaces/relation_type_service.go -destination ../interfaces/mock/mock_relation_type_service.go
 type RelationTypeService interface {
 	CheckRelationTypeExistByID(ctx context.Context, knID string, branch string, rtID string) (string, bool, error)
-	CheckRelationTypeExistByName(ctx context.Context, knID string, branch string, rtName string) (string, bool, error)
 	CreateRelationTypes(ctx context.Context, tx *sql.Tx, relationTypes []*RelationType, mode string, validateDependency bool) ([]string, error)
 	ListRelationTypes(ctx context.Context, query RelationTypesQueryParams) ([]*RelationType, int, error)
 	GetRelationTypesByIDs(ctx context.Context, knID string, branch string, rtIDs []string) ([]*RelationType, error)

--- a/bkn/bkn-backend/server/locale/relation_type.en-US.toml
+++ b/bkn/bkn-backend/server/locale/relation_type.en-US.toml
@@ -4,11 +4,6 @@ Description = "Same Relation Type ID Existed"
 Solution = "Please check whether the parameter is correct."
 ErrorLink = "None"
 
-[BknBackend.RelationType.Duplicated.Name]
-Description = "Same Relation Type Name Existed"
-Solution = "Please check whether the parameter is correct."
-ErrorLink = "None"
-
 [BknBackend.RelationType.InvalidParameter]
 Description = "Invalid Request Paramter"
 Solution = "Please check whether the parameter is correct."
@@ -21,11 +16,6 @@ ErrorLink = "None"
 
 [BknBackend.RelationType.RelationTypeIDExisted]
 Description = "Same ID Existed"
-Solution = "Please check whether the parameter is correct."
-ErrorLink = "None"
-
-[BknBackend.RelationType.RelationTypeNameExisted]
-Description = "Same Relation Type Name Existed"
 Solution = "Please check whether the parameter is correct."
 ErrorLink = "None"
 

--- a/bkn/bkn-backend/server/locale/relation_type.zh-CN.toml
+++ b/bkn/bkn-backend/server/locale/relation_type.zh-CN.toml
@@ -4,11 +4,6 @@ Description = "存在重复的关系类ID"
 Solution = "请检查参数是否正确。"
 ErrorLink = "暂无"
 
-[BknBackend.RelationType.Duplicated.Name]
-Description = "存在重复的关系类名称"
-Solution = "请检查参数是否正确。"
-ErrorLink = "暂无"
-
 [BknBackend.RelationType.InvalidParameter]
 Description = "请求参数不合法"
 Solution = "请检查参数是否正确。"
@@ -21,11 +16,6 @@ ErrorLink = "暂无"
 
 [BknBackend.RelationType.RelationTypeIDExisted]
 Description = "关系类ID已经存在"
-Solution = "请检查参数是否正确。"
-ErrorLink = "暂无"
-
-[BknBackend.RelationType.RelationTypeNameExisted]
-Description = "关系类名称已经存在"
 Solution = "请检查参数是否正确。"
 ErrorLink = "暂无"
 

--- a/bkn/bkn-backend/server/logics/relation_type/relation_type_service.go
+++ b/bkn/bkn-backend/server/logics/relation_type/relation_type_service.go
@@ -90,25 +90,6 @@ func (rts *relationTypeService) CheckRelationTypeExistByID(ctx context.Context, 
 	return rtName, exist, nil
 }
 
-func (rts *relationTypeService) CheckRelationTypeExistByName(ctx context.Context, knID string, branch string, rtName string) (string, bool, error) {
-
-	ctx, span := ar_trace.Tracer.Start(ctx, fmt.Sprintf("校验关系类[%s]的存在性", rtName))
-	defer span.End()
-
-	rtID, exist, err := rts.rta.CheckRelationTypeExistByName(ctx, knID, branch, rtName)
-	if err != nil {
-		logger.Errorf("CheckRelationTypeExistByName error: %s", err.Error())
-		// 记录处理的 sql 字符串
-		o11y.Error(ctx, fmt.Sprintf("按名称[%v]获取关系类失败: %v", rtName, err))
-		span.SetStatus(codes.Error, fmt.Sprintf("按名称[%s]获取关系类失败", rtName))
-		return rtID, exist, rest.NewHTTPError(ctx, http.StatusInternalServerError,
-			berrors.BknBackend_RelationType_InternalError_CheckRelationTypeIfExistFailed).WithErrorDetails(err.Error())
-	}
-
-	span.SetStatus(codes.Ok, "")
-	return rtID, exist, nil
-}
-
 func (rts *relationTypeService) CreateRelationTypes(ctx context.Context, tx *sql.Tx,
 	relationTypes []*interfaces.RelationType, mode string, validateDependency bool) ([]string, error) {
 
@@ -684,84 +665,30 @@ func (rts *relationTypeService) handleRelationTypeImportMode(ctx context.Context
 	// 3. 校验 若模型的id不为空，则用请求体的id与现有模型ID的重复性
 	for _, relationType := range relationTypes {
 		creates = append(creates, relationType)
-		idExist := false
 		_, idExist, err := rts.CheckRelationTypeExistByID(ctx, relationType.KNID, relationType.Branch, relationType.RTID)
 		if err != nil {
 			return creates, updates, err
 		}
 
-		// 校验 请求体与现有模型名称的重复性
-		existID, nameExist, err := rts.CheckRelationTypeExistByName(ctx, relationType.KNID, relationType.Branch, relationType.RTName)
-		if err != nil {
-			return creates, updates, err
-		}
-
 		// 根据mode来区别，若是ignore，就从结果集中忽略，若是overwrite，就调用update，若是normal就报错。
-		if idExist || nameExist {
+		if idExist {
 			switch mode {
 			case interfaces.ImportMode_Normal:
-				if idExist {
-					errDetails := fmt.Sprintf("The relation type with id [%s] already exists!", relationType.RTID)
-					logger.Error(errDetails)
-					span.SetStatus(codes.Error, errDetails)
-					return creates, updates, rest.NewHTTPError(ctx, http.StatusBadRequest,
-						berrors.BknBackend_RelationType_RelationTypeIDExisted).
-						WithErrorDetails(errDetails)
-				}
-
-				if nameExist {
-					errDetails := fmt.Sprintf("relation type name '%s' already exists", relationType.RTName)
-					logger.Error(errDetails)
-					span.SetStatus(codes.Error, errDetails)
-					return creates, updates, rest.NewHTTPError(ctx, http.StatusForbidden,
-						berrors.BknBackend_RelationType_RelationTypeNameExisted).
-						WithDescription(map[string]any{"name": relationType.RTName}).
-						WithErrorDetails(errDetails)
-				}
+				errDetails := fmt.Sprintf("The relation type with id [%s] already exists!", relationType.RTID)
+				logger.Error(errDetails)
+				span.SetStatus(codes.Error, errDetails)
+				return creates, updates, rest.NewHTTPError(ctx, http.StatusBadRequest,
+					berrors.BknBackend_RelationType_RelationTypeIDExisted).
+					WithErrorDetails(errDetails)
 
 			case interfaces.ImportMode_Ignore:
-				// 存在重复的就跳过
-				// 从create数组中删除
+				// ID 已存在则跳过，从create数组中删除
 				creates = creates[:len(creates)-1]
+
 			case interfaces.ImportMode_Overwrite:
-				if idExist && nameExist {
-					// 如果 id 和名称都存在，但是存在的名称对应的视图 id 和当前视图 id 不一样，则报错
-					if existID != relationType.RTID {
-						errDetails := fmt.Sprintf("RelationType ID '%s' and name '%s' already exist, but the exist relation type id is '%s'",
-							relationType.RTID, relationType.RTName, existID)
-						logger.Error(errDetails)
-						span.SetStatus(codes.Error, errDetails)
-						return creates, updates, rest.NewHTTPError(ctx, http.StatusForbidden,
-							berrors.BknBackend_RelationType_RelationTypeNameExisted).
-							WithErrorDetails(errDetails)
-					} else {
-						// 如果 id 和名称、度量名称都存在，存在的名称对应的模型 id 和当前模型 id 一样，则覆盖更新
-						// 从create数组中删除, 放到更新数组中
-						creates = creates[:len(creates)-1]
-						updates = append(updates, relationType)
-					}
-				}
-
-				// id 已存在，且名称不存在，覆盖更新
-				if idExist && !nameExist {
-					// 从create数组中删除, 放到更新数组中
-					creates = creates[:len(creates)-1]
-					updates = append(updates, relationType)
-				}
-
-				// 如果 id 不存在，name 存在，报错
-				if !idExist && nameExist {
-					errDetails := fmt.Sprintf("RelationType ID '%s' does not exist, but name '%s' already exists",
-						relationType.RTID, relationType.RTName)
-					logger.Error(errDetails)
-					span.SetStatus(codes.Error, errDetails)
-					return creates, updates, rest.NewHTTPError(ctx, http.StatusForbidden,
-						berrors.BknBackend_RelationType_RelationTypeNameExisted).
-						WithErrorDetails(errDetails)
-				}
-
-				// 如果 id 不存在，name不存在，度量名称不存在，不需要做什么，创建
-				// if !idExist && !nameExist {}
+				// ID 已存在则覆盖更新，从create数组中删除, 放到更新数组中
+				creates = creates[:len(creates)-1]
+				updates = append(updates, relationType)
 			}
 		}
 	}

--- a/bkn/bkn-backend/server/logics/relation_type/relation_type_service_test.go
+++ b/bkn/bkn-backend/server/logics/relation_type/relation_type_service_test.go
@@ -81,64 +81,6 @@ func Test_relationTypeService_CheckRelationTypeExistByID(t *testing.T) {
 	})
 }
 
-func Test_relationTypeService_CheckRelationTypeExistByName(t *testing.T) {
-	Convey("Test CheckRelationTypeExistByName\n", t, func() {
-		ctx := context.Background()
-		mockCtrl := gomock.NewController(t)
-		defer mockCtrl.Finish()
-
-		appSetting := &common.AppSetting{}
-		rta := bmock.NewMockRelationTypeAccess(mockCtrl)
-
-		service := &relationTypeService{
-			appSetting: appSetting,
-			rta:        rta,
-		}
-
-		Convey("Success when relation type exists\n", func() {
-			knID := "kn1"
-			branch := interfaces.MAIN_BRANCH
-			rtName := "relation_type1"
-			rtID := "rt1"
-
-			rta.EXPECT().CheckRelationTypeExistByName(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(rtID, true, nil)
-
-			id, exist, err := service.CheckRelationTypeExistByName(ctx, knID, branch, rtName)
-			So(err, ShouldBeNil)
-			So(exist, ShouldBeTrue)
-			So(id, ShouldEqual, rtID)
-		})
-
-		Convey("Success when relation type does not exist\n", func() {
-			knID := "kn1"
-			branch := interfaces.MAIN_BRANCH
-			rtName := "relation_type1"
-
-			rta.EXPECT().CheckRelationTypeExistByName(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("", false, nil)
-
-			id, exist, err := service.CheckRelationTypeExistByName(ctx, knID, branch, rtName)
-			So(err, ShouldBeNil)
-			So(exist, ShouldBeFalse)
-			So(id, ShouldEqual, "")
-		})
-
-		Convey("Failed when access layer returns error\n", func() {
-			knID := "kn1"
-			branch := interfaces.MAIN_BRANCH
-			rtName := "relation_type1"
-
-			rta.EXPECT().CheckRelationTypeExistByName(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("", false, rest.NewHTTPError(ctx, 500, berrors.BknBackend_RelationType_InternalError))
-
-			id, exist, err := service.CheckRelationTypeExistByName(ctx, knID, branch, rtName)
-			So(err, ShouldNotBeNil)
-			So(exist, ShouldBeFalse)
-			So(id, ShouldEqual, "")
-			httpErr := err.(*rest.HTTPError)
-			So(httpErr.BaseError.ErrorCode, ShouldEqual, berrors.BknBackend_RelationType_InternalError_CheckRelationTypeIfExistFailed)
-		})
-	})
-}
-
 func Test_relationTypeService_GetRelationTypeIDsByKnID(t *testing.T) {
 	Convey("Test GetRelationTypeIDsByKnID\n", t, func() {
 		ctx := context.Background()
@@ -832,7 +774,6 @@ func Test_relationTypeService_CreateRelationTypes(t *testing.T) {
 				Return(&interfaces.ObjectType{ObjectTypeWithKeyField: interfaces.ObjectTypeWithKeyField{OTID: "ot1"}}, nil).AnyTimes()
 			ots.EXPECT().CheckObjectTypeExistByID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("", true, nil).AnyTimes()
 			rta.EXPECT().CheckRelationTypeExistByID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("", false, nil).AnyTimes()
-			rta.EXPECT().CheckRelationTypeExistByName(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("", false, nil).AnyTimes()
 			rta.EXPECT().CreateRelationType(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 			vba.EXPECT().WriteDatasetDocuments(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 			smock.ExpectCommit()
@@ -877,7 +818,6 @@ func Test_relationTypeService_CreateRelationTypes(t *testing.T) {
 			smock.ExpectBegin()
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			rta.EXPECT().CheckRelationTypeExistByID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("rt1", true, nil)
-			rta.EXPECT().CheckRelationTypeExistByName(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("", false, nil)
 			smock.ExpectRollback()
 
 			result, err := service.CreateRelationTypes(ctx, nil, relationTypes, interfaces.ImportMode_Normal, true)
@@ -887,7 +827,7 @@ func Test_relationTypeService_CreateRelationTypes(t *testing.T) {
 			So(httpErr.BaseError.ErrorCode, ShouldEqual, berrors.BknBackend_RelationType_RelationTypeIDExisted)
 		})
 
-		Convey("Success with ignore mode when relation type exists\n", func() {
+		Convey("Success with ignore mode when relation type ID exists\n", func() {
 			relationTypes := []*interfaces.RelationType{
 				{
 					RelationTypeWithKeyField: interfaces.RelationTypeWithKeyField{
@@ -902,12 +842,39 @@ func Test_relationTypeService_CreateRelationTypes(t *testing.T) {
 			smock.ExpectBegin()
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			rta.EXPECT().CheckRelationTypeExistByID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("rt1", true, nil)
-			rta.EXPECT().CheckRelationTypeExistByName(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("rt1", true, nil)
 			smock.ExpectCommit()
 
 			result, err := service.CreateRelationTypes(ctx, nil, relationTypes, interfaces.ImportMode_Ignore, true)
 			So(err, ShouldBeNil)
 			So(len(result), ShouldEqual, 0)
+		})
+
+		Convey("Success with ignore mode when same name but different ID exists\n", func() {
+			relationTypes := []*interfaces.RelationType{
+				{
+					RelationTypeWithKeyField: interfaces.RelationTypeWithKeyField{
+						RTID:               "rt2",
+						RTName:             "relation_type1",
+						SourceObjectTypeID: "ot1",
+						TargetObjectTypeID: "ot2",
+					},
+					KNID:   "kn1",
+					Branch: interfaces.MAIN_BRANCH,
+				},
+			}
+
+			smock.ExpectBegin()
+			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+			rta.EXPECT().CheckRelationTypeExistByID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("", false, nil)
+			ots.EXPECT().GetObjectTypeByID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(&interfaces.ObjectType{}, nil).AnyTimes()
+			rta.EXPECT().CreateRelationType(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+			vba.EXPECT().WriteDatasetDocuments(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+			smock.ExpectCommit()
+
+			result, err := service.CreateRelationTypes(ctx, nil, relationTypes, interfaces.ImportMode_Ignore, true)
+			So(err, ShouldBeNil)
+			So(len(result), ShouldEqual, 1)
 		})
 
 		Convey("Success with Overwrite mode when ID exists\n", func() {
@@ -925,7 +892,6 @@ func Test_relationTypeService_CreateRelationTypes(t *testing.T) {
 			smock.ExpectBegin()
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 			rta.EXPECT().CheckRelationTypeExistByID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("rt1", true, nil)
-			rta.EXPECT().CheckRelationTypeExistByName(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("rt1", true, nil)
 			ots.EXPECT().GetObjectTypeByID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 				Return(&interfaces.ObjectType{}, nil).AnyTimes()
 			rta.EXPECT().UpdateRelationType(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
@@ -935,6 +901,34 @@ func Test_relationTypeService_CreateRelationTypes(t *testing.T) {
 			result, err := service.CreateRelationTypes(ctx, nil, relationTypes, interfaces.ImportMode_Overwrite, true)
 			So(err, ShouldBeNil)
 			So(len(result), ShouldEqual, 0)
+		})
+
+		Convey("Success with Overwrite mode when same name but different ID - creates new record\n", func() {
+			relationTypes := []*interfaces.RelationType{
+				{
+					RelationTypeWithKeyField: interfaces.RelationTypeWithKeyField{
+						RTID:               "rt2",
+						RTName:             "relation_type1",
+						SourceObjectTypeID: "ot1",
+						TargetObjectTypeID: "ot2",
+					},
+					KNID:   "kn1",
+					Branch: interfaces.MAIN_BRANCH,
+				},
+			}
+
+			smock.ExpectBegin()
+			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+			rta.EXPECT().CheckRelationTypeExistByID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("", false, nil)
+			ots.EXPECT().GetObjectTypeByID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(&interfaces.ObjectType{}, nil).AnyTimes()
+			rta.EXPECT().CreateRelationType(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+			vba.EXPECT().WriteDatasetDocuments(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+			smock.ExpectCommit()
+
+			result, err := service.CreateRelationTypes(ctx, nil, relationTypes, interfaces.ImportMode_Overwrite, true)
+			So(err, ShouldBeNil)
+			So(len(result), ShouldEqual, 1)
 		})
 
 		Convey("Success with empty RTID generates new ID\n", func() {
@@ -954,7 +948,6 @@ func Test_relationTypeService_CreateRelationTypes(t *testing.T) {
 			rta.EXPECT().CheckRelationTypeExistByID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Do(func(ctx, knID, branch, rtID interface{}) {
 				So(rtID, ShouldNotBeEmpty)
 			}).Return("", false, nil)
-			rta.EXPECT().CheckRelationTypeExistByName(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("", false, nil)
 			ots.EXPECT().GetObjectTypeByID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 				Return(&interfaces.ObjectType{}, nil).AnyTimes()
 			rta.EXPECT().CreateRelationType(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
@@ -1008,7 +1001,6 @@ func Test_relationTypeService_CreateRelationTypes(t *testing.T) {
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			ots.EXPECT().GetObjectTypeByID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(&interfaces.ObjectType{}, nil).AnyTimes()
 			rta.EXPECT().CheckRelationTypeExistByID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("", false, nil)
-			rta.EXPECT().CheckRelationTypeExistByName(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("", false, nil)
 			rta.EXPECT().CreateRelationType(gomock.Any(), gomock.Any(), gomock.Any()).Return(rest.NewHTTPError(ctx, 500, berrors.BknBackend_RelationType_InternalError))
 			smock.ExpectRollback()
 
@@ -1033,7 +1025,6 @@ func Test_relationTypeService_CreateRelationTypes(t *testing.T) {
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			ots.EXPECT().GetObjectTypeByID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(&interfaces.ObjectType{}, nil).AnyTimes()
 			rta.EXPECT().CheckRelationTypeExistByID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("", false, nil)
-			rta.EXPECT().CheckRelationTypeExistByName(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("", false, nil)
 			rta.EXPECT().CreateRelationType(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			vba.EXPECT().WriteDatasetDocuments(gomock.Any(), gomock.Any(), gomock.Any()).Return(rest.NewHTTPError(ctx, 500, berrors.BknBackend_RelationType_InternalError))
 			smock.ExpectRollback()

--- a/sql/dm8_init.sql
+++ b/sql/dm8_init.sql
@@ -1,4 +1,4 @@
--- Source: bkn/bkn-backend/migrations/dm8/0.4.0/pre/init.sql
+-- Source: bkn/bkn-backend/migrations/dm8/0.5.0/pre/init.sql
 -- Copyright The kweaver.ai Authors.
 --
 -- Licensed under the Apache License, Version 2.0.
@@ -94,8 +94,6 @@ CREATE TABLE IF NOT EXISTS t_relation_type (
   f_update_time BIGINT NOT NULL DEFAULT 0,
   CLUSTER PRIMARY KEY (f_kn_id,f_branch,f_id)
 );
-
-CREATE UNIQUE INDEX IF NOT EXISTS uk_t_relation_type_rt_name ON t_relation_type(f_kn_id,f_branch,f_name);
 
 
 CREATE TABLE IF NOT EXISTS t_action_type (

--- a/sql/mariadb_init.sql
+++ b/sql/mariadb_init.sql
@@ -1,4 +1,4 @@
--- Source: bkn/bkn-backend/migrations/mariadb/0.4.0/pre/init.sql
+-- Source: bkn/bkn-backend/migrations/mariadb/0.5.0/pre/init.sql
 -- Copyright The kweaver.ai Authors.
 --
 -- Licensed under the Apache License, Version 2.0.
@@ -90,8 +90,7 @@ CREATE TABLE IF NOT EXISTS t_relation_type (
   f_updater VARCHAR(40) NOT NULL DEFAULT '' COMMENT '更新者id',
   f_updater_type VARCHAR(20) NOT NULL DEFAULT '' COMMENT '更新者类型',
   f_update_time BIGINT(20) NOT NULL DEFAULT 0 COMMENT '更新时间',
-  PRIMARY KEY (f_kn_id,f_branch,f_id),
-  UNIQUE KEY uk_relation_type_name (f_kn_id,f_branch,f_name)
+  PRIMARY KEY (f_kn_id,f_branch,f_id)
 ) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_bin COMMENT = '关系类';
 
 -- 行动类


### PR DESCRIPTION
移除关系类名称的唯一性约束，包括数据库索引、校验逻辑和错误提示。现在同一BKN内允许存在同名关系类，仅通过ID保证唯一性。

- 删除数据库中的关系类名称唯一索引
- 移除名称重复性校验逻辑和相关接口方法
- 删除名称重复的错误提示和国际化配置
- 更新相关测试用例以适配新逻辑