### PR TITLE
[fix] (vega-backend) 补充catalog删除限制

### DIFF
--- a/vega/vega-backend/migrations/dm8/0.5.0/pre/init.sql
+++ b/vega/vega-backend/migrations/dm8/0.5.0/pre/init.sql
@@ -329,6 +329,20 @@ SELECT 'opensearch', 'opensearch', 'OpenSearch 搜索引擎连接器', 'local', 
     1
 FROM DUAL WHERE NOT EXISTS ( SELECT f_type FROM t_connector_type WHERE f_type = 'opensearch' );
 
+INSERT INTO t_connector_type (f_type, f_name, f_description, f_mode, f_category, f_field_config, f_enabled)
+SELECT 'postgresql', 'postgresql', 'PostgreSQL 关系型数据库连接器', 'local', 'table',
+       '{
+           "host":      {"name":"主机地址","type":"string","description":"数据库服务器主机地址","required":true,"encrypted":false},
+           "port":      {"name":"端口号","type":"integer","description":"数据库服务器端口","required":true,"encrypted":false},
+           "username":  {"name":"用户名","type":"string","description":"数据库用户名","required":true,"encrypted":false},
+           "password":  {"name":"密码","type":"string","description":"数据库密码","required":true,"encrypted":true},
+           "database":  {"name":"数据库名","type":"string","description":"PostgreSQL 连接目标 database","required":true,"encrypted":false},
+           "schemas":   {"name":"Schema 列表","type":"array","description":"可选；为空则扫描当前库下除系统 schema 外的用户 schema；非空则仅扫描列出的 schema","required":false,"encrypted":false},
+           "options":   {"name":"连接参数","type":"object","description":"连接参数（如 sslmode、connect_timeout 等）","required":false,"encrypted":false}
+       }',
+       1
+FROM DUAL WHERE NOT EXISTS ( SELECT f_type FROM t_connector_type WHERE f_type = 'postgresql' );
+
 -- ==========================================
 -- 7. t_discover_task 发现任务表
 -- ==========================================

--- a/vega/vega-backend/migrations/mariadb/0.5.0/pre/init.sql
+++ b/vega/vega-backend/migrations/mariadb/0.5.0/pre/init.sql
@@ -318,6 +318,20 @@ SELECT 'opensearch', 'opensearch', 'OpenSearch 搜索引擎连接器', 'local', 
     TRUE
 FROM DUAL WHERE NOT EXISTS ( SELECT f_type FROM t_connector_type WHERE f_type = 'opensearch' );
 
+INSERT INTO t_connector_type (f_type, f_name, f_description, f_mode, f_category, f_field_config, f_enabled)
+SELECT 'postgresql', 'postgresql', 'PostgreSQL 关系型数据库连接器', 'local', 'table',
+       '{
+           "host":      {"name":"主机地址","type":"string","description":"数据库服务器主机地址","required":true,"encrypted":false},
+           "port":      {"name":"端口号","type":"integer","description":"数据库服务器端口","required":true,"encrypted":false},
+           "username":  {"name":"用户名","type":"string","description":"数据库用户名","required":true,"encrypted":false},
+           "password":  {"name":"密码","type":"string","description":"数据库密码","required":true,"encrypted":true},
+           "database":  {"name":"数据库名","type":"string","description":"PostgreSQL 连接目标 database","required":true,"encrypted":false},
+           "schemas":   {"name":"Schema 列表","type":"array","description":"可选；为空则扫描当前库下除系统 schema 外的用户 schema；非空则仅扫描列出的 schema","required":false,"encrypted":false},
+           "options":   {"name":"连接参数","type":"object","description":"连接参数（如 sslmode、connect_timeout 等）","required":false,"encrypted":false}
+       }',
+       TRUE
+FROM DUAL WHERE NOT EXISTS ( SELECT f_type FROM t_connector_type WHERE f_type = 'postgresql' );
+
 -- ==========================================
 -- 7. t_discover_task 发现任务表
 -- ==========================================

--- a/vega/vega-backend/server/drivenadapters/discover_task/discover_task_access.go
+++ b/vega/vega-backend/server/drivenadapters/discover_task/discover_task_access.go
@@ -372,3 +372,31 @@ func (da *discoverTaskAccess) UpdateResult(ctx context.Context, id string, resul
 	span.SetStatus(codes.Ok, "")
 	return nil
 }
+
+// CheckExistByStatuses checks if DiscoverTasks exist by catalog ID and statuses.
+func (da *discoverTaskAccess) CheckExistByStatuses(ctx context.Context, catalogID string, statuses []string) (bool, error) {
+	ctx, span := ar_trace.Tracer.Start(ctx, "Check discover_tasks exist",
+		trace.WithSpanKind(trace.SpanKindClient))
+	defer span.End()
+
+	countBuilder := sq.Select("COUNT(*)").From(DISCOVER_TASK_TABLE_NAME)
+
+	if catalogID != "" {
+		countBuilder = countBuilder.Where(sq.Eq{"f_catalog_id": catalogID})
+	}
+	if len(statuses) > 0 {
+		countBuilder = countBuilder.Where(sq.Eq{"f_status": statuses})
+	}
+
+	countSql, countVals, _ := countBuilder.ToSql()
+	var total int64
+	err := da.db.QueryRowContext(ctx, countSql, countVals...).Scan(&total)
+	if err != nil {
+		logger.Errorf("Failed to count discover_tasks: %v", err)
+		span.SetStatus(codes.Error, "Count failed")
+		return false, err
+	}
+
+	span.SetStatus(codes.Ok, "")
+	return total > 0, nil
+}

--- a/vega/vega-backend/server/drivenadapters/resource/resource_access.go
+++ b/vega/vega-backend/server/drivenadapters/resource/resource_access.go
@@ -782,7 +782,7 @@ func (ra *resourceAccess) DeleteByIDs(ctx context.Context, ids []string) error {
 
 // ListResourceSrcs lists Resource Sources with filters.
 func (ra *resourceAccess) ListResourceSrcs(ctx context.Context, params interfaces.ListResourcesQueryParams) ([]*interfaces.ListResourceEntry, int64, error) {
-	ctx, span := ar_trace.Tracer.Start(ctx, "ListResourceSrcs resources",
+	ctx, span := ar_trace.Tracer.Start(ctx, "ListResourceSrcs",
 		trace.WithSpanKind(trace.SpanKindClient))
 	defer span.End()
 
@@ -853,97 +853,33 @@ func (ra *resourceAccess) ListResourceSrcs(ctx context.Context, params interface
 	return entries, total, nil
 }
 
-func (ra *resourceAccess) GetByCategorys(ctx context.Context, catalogID string, categorys []string) ([]*interfaces.Resource, error) {
-	ctx, span := ar_trace.Tracer.Start(ctx, "Query resources by catalog ID and categorys",
+func (ra *resourceAccess) CheckExistByCategories(ctx context.Context, catalogID string, categories []string) (bool, error) {
+	ctx, span := ar_trace.Tracer.Start(ctx, "Check resources exist",
 		trace.WithSpanKind(trace.SpanKindClient))
 	defer span.End()
 
 	span.SetAttributes(attr.Key("catalog_id").String(catalogID))
 
-	sqlStr, vals, err := sq.Select(
-		"f_id",
-		"f_catalog_id",
-		"f_name",
-		"f_tags",
-		"f_description",
-		"f_category",
-		"f_status",
-		"f_status_message",
-		"f_database",
-		"f_source_identifier",
-		"f_source_metadata",
-		"f_schema_definition",
-		"f_creator",
-		"f_creator_type",
-		"f_create_time",
-		"f_updater",
-		"f_updater_type",
-		"f_update_time",
-	).From(RESOURCE_TABLE_NAME).
-		Where(sq.Eq{"f_catalog_id": catalogID}).
-		Where(sq.Eq{"f_category": categorys}).
-		ToSql()
-	if err != nil {
-		logger.Errorf("Failed to build query resources sql: %v", err)
-		span.SetStatus(codes.Error, "Build sql failed")
-		return nil, err
+	countBuilder := sq.Select("COUNT(*)").From(RESOURCE_TABLE_NAME)
+
+	if catalogID != "" {
+		countBuilder = countBuilder.Where(sq.Eq{"f_catalog_id": catalogID})
+	}
+	if len(categories) > 0 {
+		countBuilder = countBuilder.Where(sq.Eq{"f_category": categories})
 	}
 
-	rows, err := ra.db.QueryContext(ctx, sqlStr, vals...)
+	countSql, countVals, _ := countBuilder.ToSql()
+	var total int64
+	err := ra.db.QueryRowContext(ctx, countSql, countVals...).Scan(&total)
 	if err != nil {
-		logger.Errorf("Query resources failed: %v", err)
-		span.SetStatus(codes.Error, "Query failed")
-		return nil, err
-	}
-	defer rows.Close()
-
-	resources := make([]*interfaces.Resource, 0)
-	for rows.Next() {
-		resource := &interfaces.Resource{}
-		var tagsStr string
-		var database, sourceIdentifier, sourceMetadata, schemaDefinition sql.NullString
-
-		err := rows.Scan(
-			&resource.ID,
-			&resource.CatalogID,
-			&resource.Name,
-			&tagsStr,
-			&resource.Description,
-			&resource.Category,
-			&resource.Status,
-			&resource.StatusMessage,
-			&database,
-			&sourceIdentifier,
-			&sourceMetadata,
-			&schemaDefinition,
-			&resource.Creator.ID,
-			&resource.Creator.Type,
-			&resource.CreateTime,
-			&resource.Updater.ID,
-			&resource.Updater.Type,
-			&resource.UpdateTime,
-		)
-		if err != nil {
-			logger.Errorf("Scan resource row failed: %v", err)
-			span.SetStatus(codes.Error, "Scan row failed")
-			return nil, err
-		}
-
-		resource.Tags = libCommon.TagString2TagSlice(tagsStr)
-		resource.Database = database.String
-		resource.SourceIdentifier = sourceIdentifier.String
-		if sourceMetadata.Valid && sourceMetadata.String != "" {
-			_ = json.Unmarshal([]byte(sourceMetadata.String), &resource.SourceMetadata)
-		}
-		if schemaDefinition.Valid && schemaDefinition.String != "" {
-			_ = json.Unmarshal([]byte(schemaDefinition.String), &resource.SchemaDefinition)
-		}
-
-		resources = append(resources, resource)
+		logger.Errorf("Failed to count resources: %v", err)
+		span.SetStatus(codes.Error, "Count failed")
+		return false, err
 	}
 
 	span.SetStatus(codes.Ok, "")
-	return resources, nil
+	return total > 0, nil
 }
 
 func (ra *resourceAccess) DeleteByCatalogIDs(ctx context.Context, catalogIDs []string) error {

--- a/vega/vega-backend/server/driveradapters/catalog_handler.go
+++ b/vega/vega-backend/server/driveradapters/catalog_handler.go
@@ -498,8 +498,24 @@ func (r *restHandler) deleteCatalogs(c *gin.Context, ctx context.Context, span t
 			return
 		}
 
+		// check if catalog discover tasks exists
+		exists, err = r.dts.CheckExistByStatuses(ctx, id, []string{interfaces.DiscoverTaskStatusPending, interfaces.DiscoverTaskStatusRunning})
+		if err != nil {
+			httpErr := err.(*rest.HTTPError)
+			o11y.AddHttpAttrs4HttpError(span, httpErr)
+			rest.ReplyError(c, httpErr)
+			return
+		}
+		if exists {
+			httpErr := rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_Catalog_InvalidParameter).
+				WithErrorDetails(fmt.Sprintf("catalog %s contains tasks in the pending or running statuses and cannot be deleted.", id))
+			o11y.AddHttpAttrs4HttpError(span, httpErr)
+			rest.ReplyError(c, httpErr)
+			return
+		}
+
 		// check if catalog resources exists
-		exists, err = r.rs.CheckExistByCategorys(ctx, id, []string{interfaces.ResourceCategoryDataset, interfaces.ResourceCategoryLogicView})
+		exists, err = r.rs.CheckExistByCategories(ctx, id, []string{interfaces.ResourceCategoryDataset, interfaces.ResourceCategoryLogicView})
 		if err != nil {
 			httpErr := err.(*rest.HTTPError)
 			o11y.AddHttpAttrs4HttpError(span, httpErr)
@@ -513,6 +529,7 @@ func (r *restHandler) deleteCatalogs(c *gin.Context, ctx context.Context, span t
 			rest.ReplyError(c, httpErr)
 			return
 		}
+
 	}
 
 	if err := r.cs.DeleteByIDs(ctx, ids); err != nil {

--- a/vega/vega-backend/server/interfaces/discover_task_access.go
+++ b/vega/vega-backend/server/interfaces/discover_task_access.go
@@ -24,4 +24,7 @@ type DiscoverTaskAccess interface {
 	UpdateProgress(ctx context.Context, id string, progress int) error
 	// UpdateResult updates a DiscoverTask's result and sets status to completed.
 	UpdateResult(ctx context.Context, id string, result *DiscoverResult, stime int64) error
+
+	// CheckExistByStatuses checks if DiscoverTasks exists by catalog ID and statuses.
+	CheckExistByStatuses(ctx context.Context, catalogID string, statuses []string) (bool, error)
 }

--- a/vega/vega-backend/server/interfaces/discover_task_service.go
+++ b/vega/vega-backend/server/interfaces/discover_task_service.go
@@ -22,4 +22,7 @@ type DiscoverTaskService interface {
 	UpdateStatus(ctx context.Context, id string, status string, message string, stime int64) error
 	// UpdateResult updates a DiscoverTask's result.
 	UpdateResult(ctx context.Context, id string, result *DiscoverResult, stime int64) error
+
+	// CheckExistByStatuses  checks if DiscoverTasks exists by catalog ID and statuses.
+	CheckExistByStatuses(ctx context.Context, catalogID string, statuses []string) (bool, error)
 }

--- a/vega/vega-backend/server/interfaces/mock/mock_discover_task_access.go
+++ b/vega/vega-backend/server/interfaces/mock/mock_discover_task_access.go
@@ -41,6 +41,21 @@ func (m *MockDiscoverTaskAccess) EXPECT() *MockDiscoverTaskAccessMockRecorder {
 	return m.recorder
 }
 
+// CheckExistByStatuses mocks base method.
+func (m *MockDiscoverTaskAccess) CheckExistByStatuses(ctx context.Context, catalogID string, statuses []string) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CheckExistByStatuses", ctx, catalogID, statuses)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CheckExistByStatuses indicates an expected call of CheckExistByStatuses.
+func (mr *MockDiscoverTaskAccessMockRecorder) CheckExistByStatuses(ctx, catalogID, statuses any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckExistByStatuses", reflect.TypeOf((*MockDiscoverTaskAccess)(nil).CheckExistByStatuses), ctx, catalogID, statuses)
+}
+
 // Create mocks base method.
 func (m *MockDiscoverTaskAccess) Create(ctx context.Context, task *interfaces.DiscoverTask) error {
 	m.ctrl.T.Helper()

--- a/vega/vega-backend/server/interfaces/mock/mock_discover_task_service.go
+++ b/vega/vega-backend/server/interfaces/mock/mock_discover_task_service.go
@@ -41,6 +41,21 @@ func (m *MockDiscoverTaskService) EXPECT() *MockDiscoverTaskServiceMockRecorder 
 	return m.recorder
 }
 
+// CheckExistByStatuses mocks base method.
+func (m *MockDiscoverTaskService) CheckExistByStatuses(ctx context.Context, catalogID string, statuses []string) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CheckExistByStatuses", ctx, catalogID, statuses)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CheckExistByStatuses indicates an expected call of CheckExistByStatuses.
+func (mr *MockDiscoverTaskServiceMockRecorder) CheckExistByStatuses(ctx, catalogID, statuses any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckExistByStatuses", reflect.TypeOf((*MockDiscoverTaskService)(nil).CheckExistByStatuses), ctx, catalogID, statuses)
+}
+
 // Create mocks base method.
 func (m *MockDiscoverTaskService) Create(ctx context.Context, catalogID string) (string, error) {
 	m.ctrl.T.Helper()

--- a/vega/vega-backend/server/interfaces/mock/mock_resource_access.go
+++ b/vega/vega-backend/server/interfaces/mock/mock_resource_access.go
@@ -41,6 +41,21 @@ func (m *MockResourceAccess) EXPECT() *MockResourceAccessMockRecorder {
 	return m.recorder
 }
 
+// CheckExistByCategories mocks base method.
+func (m *MockResourceAccess) CheckExistByCategories(ctx context.Context, catalogID string, categories []string) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CheckExistByCategories", ctx, catalogID, categories)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CheckExistByCategories indicates an expected call of CheckExistByCategories.
+func (mr *MockResourceAccessMockRecorder) CheckExistByCategories(ctx, catalogID, categories any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckExistByCategories", reflect.TypeOf((*MockResourceAccess)(nil).CheckExistByCategories), ctx, catalogID, categories)
+}
+
 // Create mocks base method.
 func (m *MockResourceAccess) Create(ctx context.Context, resource *interfaces.Resource) error {
 	m.ctrl.T.Helper()
@@ -96,21 +111,6 @@ func (m *MockResourceAccess) GetByCatalogID(ctx context.Context, catalogID strin
 func (mr *MockResourceAccessMockRecorder) GetByCatalogID(ctx, catalogID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByCatalogID", reflect.TypeOf((*MockResourceAccess)(nil).GetByCatalogID), ctx, catalogID)
-}
-
-// GetByCategorys mocks base method.
-func (m *MockResourceAccess) GetByCategorys(ctx context.Context, catalogID string, category []string) ([]*interfaces.Resource, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetByCategorys", ctx, catalogID, category)
-	ret0, _ := ret[0].([]*interfaces.Resource)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetByCategorys indicates an expected call of GetByCategorys.
-func (mr *MockResourceAccessMockRecorder) GetByCategorys(ctx, catalogID, category any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByCategorys", reflect.TypeOf((*MockResourceAccess)(nil).GetByCategorys), ctx, catalogID, category)
 }
 
 // GetByID mocks base method.

--- a/vega/vega-backend/server/interfaces/mock/mock_resource_service.go
+++ b/vega/vega-backend/server/interfaces/mock/mock_resource_service.go
@@ -41,19 +41,19 @@ func (m *MockResourceService) EXPECT() *MockResourceServiceMockRecorder {
 	return m.recorder
 }
 
-// CheckExistByCategorys mocks base method.
-func (m *MockResourceService) CheckExistByCategorys(ctx context.Context, catalogID string, categorys []string) (bool, error) {
+// CheckExistByCategories mocks base method.
+func (m *MockResourceService) CheckExistByCategories(ctx context.Context, catalogID string, categories []string) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CheckExistByCategorys", ctx, catalogID, categorys)
+	ret := m.ctrl.Call(m, "CheckExistByCategories", ctx, catalogID, categories)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// CheckExistByCategorys indicates an expected call of CheckExistByCategorys.
-func (mr *MockResourceServiceMockRecorder) CheckExistByCategorys(ctx, catalogID, categorys any) *gomock.Call {
+// CheckExistByCategories indicates an expected call of CheckExistByCategories.
+func (mr *MockResourceServiceMockRecorder) CheckExistByCategories(ctx, catalogID, categories any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckExistByCategorys", reflect.TypeOf((*MockResourceService)(nil).CheckExistByCategorys), ctx, catalogID, categorys)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckExistByCategories", reflect.TypeOf((*MockResourceService)(nil).CheckExistByCategories), ctx, catalogID, categories)
 }
 
 // CheckExistByID mocks base method.

--- a/vega/vega-backend/server/interfaces/resource_access.go
+++ b/vega/vega-backend/server/interfaces/resource_access.go
@@ -33,8 +33,8 @@ type ResourceAccess interface {
 	// ListResourceSrcs lists Resource Sources with filters.
 	ListResourceSrcs(ctx context.Context, params ListResourcesQueryParams) ([]*ListResourceEntry, int64, error)
 
-	// GetByCategorys  lists Resource by catalog and categorys.
-	GetByCategorys(ctx context.Context, catalogID string, category []string) ([]*Resource, error)
+	// CheckExistByCategories checks if Resources exists by catalog ID and categories.
+	CheckExistByCategories(ctx context.Context, catalogID string, categories []string) (bool, error)
 
 	// DeleteByCatalogIDs deletes Resources by catalog IDs.
 	DeleteByCatalogIDs(ctx context.Context, catalogIDs []string) error

--- a/vega/vega-backend/server/interfaces/resource_service.go
+++ b/vega/vega-backend/server/interfaces/resource_service.go
@@ -40,6 +40,6 @@ type ResourceService interface {
 	// ListResourceSrcs lists Resource Sources with filters.
 	ListResourceSrcs(ctx context.Context, params ListResourcesQueryParams) ([]*ListResourceEntry, int64, error)
 
-	// CheckExistByCategorys checks if Resources exists by catalog ID and categorys.
-	CheckExistByCategorys(ctx context.Context, catalogID string, categorys []string) (bool, error)
+	// CheckExistByCategories checks if Resources exists by catalog ID and categories.
+	CheckExistByCategories(ctx context.Context, catalogID string, categories []string) (bool, error)
 }

--- a/vega/vega-backend/server/logics/discover_task/discover_task_service.go
+++ b/vega/vega-backend/server/logics/discover_task/discover_task_service.go
@@ -151,3 +151,12 @@ func (dts *discoverTaskService) UpdateResult(ctx context.Context, id string, res
 
 	return dts.dta.UpdateResult(ctx, id, result, stime)
 }
+
+// CheckExistByStatuses checks if DiscoverTasks exists by catalog ID and statuses.
+func (dts *discoverTaskService) CheckExistByStatuses(ctx context.Context, catalogID string, statuses []string) (bool, error) {
+	ctx, span := ar_trace.Tracer.Start(ctx, "DiscoverTaskService.CheckExistByStatuses",
+		trace.WithSpanKind(trace.SpanKindServer))
+	defer span.End()
+
+	return dts.dta.CheckExistByStatuses(ctx, catalogID, statuses)
+}

--- a/vega/vega-backend/server/logics/resource/resource_service.go
+++ b/vega/vega-backend/server/logics/resource/resource_service.go
@@ -563,13 +563,13 @@ func (rs *resourceService) UpdateResource(ctx context.Context, resource *interfa
 
 // ListResourceSrcs lists Resource Sources with filters.
 func (rs *resourceService) ListResourceSrcs(ctx context.Context, params interfaces.ListResourcesQueryParams) ([]*interfaces.ListResourceEntry, int64, error) {
-	ctx, span := ar_trace.Tracer.Start(ctx, "ListResourceSrcs resources")
+	ctx, span := ar_trace.Tracer.Start(ctx, "ListResourceSrcs")
 	defer span.End()
 
 	// 使用ra.ListResourceSrcs函数查询resources
 	entries, total, err := rs.ra.ListResourceSrcs(ctx, params)
 	if err != nil {
-		span.SetStatus(codes.Error, "ListResourceSrcs resources failed")
+		span.SetStatus(codes.Error, "ListResourceSrcs failed")
 		return []*interfaces.ListResourceEntry{}, 0, rest.NewHTTPError(ctx, http.StatusInternalServerError, verrors.VegaBackend_Resource_InternalError_GetFailed).
 			WithErrorDetails(err.Error())
 	}
@@ -635,18 +635,10 @@ func (rs *resourceService) ListResourceSrcs(ctx context.Context, params interfac
 	return results[params.Offset:end], int64(resTotal), nil
 }
 
-// CheckExistByCategorys checks if Resources exists by catalog ID and categorys.
-func (rs *resourceService) CheckExistByCategorys(ctx context.Context, catalogID string, categorys []string) (bool, error) {
-	ctx, span := ar_trace.Tracer.Start(ctx, "Check resource exist by catalog ID and categorys")
+// CheckExistByCategories checks if Resources exists by catalog ID and categories.
+func (rs *resourceService) CheckExistByCategories(ctx context.Context, catalogID string, categories []string) (bool, error) {
+	ctx, span := ar_trace.Tracer.Start(ctx, "CheckExistByCategories")
 	defer span.End()
 
-	resources, err := rs.ra.GetByCategorys(ctx, catalogID, categorys)
-	if err != nil {
-		span.SetStatus(codes.Error, "Get resources failed")
-		return false, rest.NewHTTPError(ctx, http.StatusInternalServerError, verrors.VegaBackend_Resource_InternalError_GetFailed).
-			WithErrorDetails(err.Error())
-	}
-
-	span.SetStatus(codes.Ok, "")
-	return len(resources) > 0, nil
+	return rs.ra.CheckExistByCategories(ctx, catalogID, categories)
 }


### PR DESCRIPTION
补充catalog删除限制:
1、存在未执行完成(pending/running)的扫描任务的catalog不允许删除
2、存在非扫描类型(dataset/logicview)的resource数据的catalog不允许删除