### PR TITLE
同步视图的一些bug修复

### DIFF
--- a/vega/mdl-data-model/helm/mdl-data-model/values.yaml
+++ b/vega/mdl-data-model/helm/mdl-data-model/values.yaml
@@ -107,6 +107,7 @@ config:
     - 1d
     watchMetadataInterval: 60  # 单位为秒
     watchMetadataEnabled: true
+    watchMetadataBatchSize: 100
   log:
     logLevel: info
     developMode: false

--- a/vega/mdl-data-model/server/common/setting.go
+++ b/vega/mdl-data-model/server/common/setting.go
@@ -25,14 +25,15 @@ import (
 
 // server配置项
 type ServerSetting struct {
-	RunMode               string        `mapstructure:"runMode"`
-	HttpPort              int           `mapstructure:"httpPort"`
-	Language              string        `mapstructure:"language"`
-	ReadTimeOut           time.Duration `mapstructure:"readTimeOut"`
-	WriteTimeout          time.Duration `mapstructure:"writeTimeOut"`
-	PersistSteps          []string      `mapstructure:"persistSteps"`
-	WatchMetadataInterval time.Duration `mapstructure:"watchMetadataInterval"`
-	WatchMetadataEnabled  bool          `mapstructure:"watchMetadataEnabled"`
+	RunMode                string        `mapstructure:"runMode"`
+	HttpPort               int           `mapstructure:"httpPort"`
+	Language               string        `mapstructure:"language"`
+	ReadTimeOut            time.Duration `mapstructure:"readTimeOut"`
+	WriteTimeout           time.Duration `mapstructure:"writeTimeOut"`
+	PersistSteps           []string      `mapstructure:"persistSteps"`
+	WatchMetadataInterval  time.Duration `mapstructure:"watchMetadataInterval"`
+	WatchMetadataEnabled   bool          `mapstructure:"watchMetadataEnabled"`
+	WatchMetadataBatchSize int           `mapstructure:"watchMetadataBatchSize"`
 }
 
 type ThirdParty struct {

--- a/vega/mdl-data-model/server/config/data-model-config.yaml
+++ b/vega/mdl-data-model/server/config/data-model-config.yaml
@@ -7,6 +7,7 @@ server:
   persistSteps: [5m, 10m, 15m, 20m, 30m, 1h, 2h, 3h, 6h, 12h, 1d]
   watchMetadataInterval: 60 # 单位为秒
   watchMetadataEnabled: true
+  watchMetadataBatchSize: 100
 log:
   logLevel: debug
   developMode: false

--- a/vega/mdl-data-model/server/drivenadapters/data_view/data_view_access.go
+++ b/vega/mdl-data-model/server/drivenadapters/data_view/data_view_access.go
@@ -274,16 +274,6 @@ func (dva *dataViewAccess) UpdateDataView(ctx context.Context, tx *sql.Tx, view 
 	tagsStr := libCommon.TagSlice2TagString(view.Tags)
 	primaryKeysStr := libCommon.TagSlice2TagString(view.PrimaryKeys)
 
-	// dataSourceBytes, err := sonic.Marshal(view.DataSource)
-	// if err != nil {
-	// 	errDetails := fmt.Sprintf("Marshal dataSource failed, %s", err.Error())
-	// 	logger.Error(errDetails)
-	// 	o11y.Error(ctx, errDetails)
-	// 	span.SetStatus(codes.Error, "Marshal dataSource failed")
-
-	// 	return err
-	// }
-
 	excelConfigBytes, err := sonic.Marshal(view.ExcelConfig)
 	if err != nil {
 		errDetails := fmt.Sprintf("Marshal excelConfig failed, %s", err.Error())
@@ -313,16 +303,6 @@ func (dva *dataViewAccess) UpdateDataView(ctx context.Context, tx *sql.Tx, view 
 
 		return err
 	}
-
-	// condBytes, err := sonic.Marshal(view.Condition)
-	// if err != nil {
-	// 	errDetails := fmt.Sprintf("Marshal condition failed, %s", err.Error())
-	// 	logger.Error(errDetails)
-	// 	o11y.Error(ctx, errDetails)
-	// 	span.SetStatus(codes.Error, "Marshal condition failed")
-
-	// 	return err
-	// }
 
 	updateMap := map[string]any{
 		"f_view_name":    view.ViewName,
@@ -370,6 +350,98 @@ func (dva *dataViewAccess) UpdateDataView(ctx context.Context, tx *sql.Tx, view 
 		span.SetStatus(codes.Error, "Update data view failed")
 
 		return err
+	}
+
+	span.SetStatus(codes.Ok, "")
+	return nil
+}
+
+// 批量修改数据视图
+func (dva *dataViewAccess) UpdateDataViews(ctx context.Context, tx *sql.Tx, views []*interfaces.DataView) error {
+	_, span := ar_trace.Tracer.Start(ctx, "driven layer: Update data views from DB", trace.WithSpanKind(trace.SpanKindClient))
+	defer span.End()
+
+	if len(views) == 0 {
+		return nil
+	}
+
+	span.SetAttributes(
+		attr.Key("db_url").String(libdb.GetDBUrl()),
+		attr.Key("db_type").String(libdb.GetDBType()),
+		attr.Key("view_count").Int(len(views)),
+	)
+
+	// 如果没有传入事务，则内部开启事务
+	var internalTx *sql.Tx
+	var err error
+	if tx == nil {
+		internalTx, err = dva.db.Begin()
+		if err != nil {
+			return err
+		}
+		defer func() {
+			if err != nil {
+				if rbErr := internalTx.Rollback(); rbErr != nil {
+					logger.Errorf("failed to rollback update views transaction: %v", rbErr)
+				}
+			} else {
+				if cmErr := internalTx.Commit(); cmErr != nil {
+					logger.Errorf("failed to commit update views transaction: %v", cmErr)
+				}
+			}
+		}()
+		tx = internalTx
+	}
+
+	for _, view := range views {
+		tagsStr := libCommon.TagSlice2TagString(view.Tags)
+		primaryKeysStr := libCommon.TagSlice2TagString(view.PrimaryKeys)
+
+		excelConfigBytes, err := sonic.Marshal(view.ExcelConfig)
+		if err != nil {
+			return fmt.Errorf("marshal excelConfig failed for view %s: %w", view.ViewID, err)
+		}
+
+		dataScopeBytes, err := sonic.Marshal(view.DataScope)
+		if err != nil {
+			return fmt.Errorf("marshal dataScope failed for view %s: %w", view.ViewID, err)
+		}
+
+		fieldsBytes, err := sonic.Marshal(view.Fields)
+		if err != nil {
+			return fmt.Errorf("marshal fields failed for view %s: %w", view.ViewID, err)
+		}
+
+		updateMap := map[string]any{
+			"f_view_name":    view.ViewName,
+			"f_group_id":     view.GroupID,
+			"f_query_type":   view.QueryType,
+			"f_tags":         tagsStr,
+			"f_comment":      view.Comment,
+			"f_file_name":    view.FileName,
+			"f_excel_config": excelConfigBytes,
+			"f_data_scope":   dataScopeBytes,
+			"f_fields":       fieldsBytes,
+			"f_primary_keys": primaryKeysStr,
+			"f_sql":          view.SQLStr,
+			"f_status":       view.Status,
+			"f_update_time":  view.UpdateTime,
+			"f_updater":      view.Updater.ID,
+			"f_updater_type": view.Updater.Type,
+		}
+
+		sqlStr, args, err := sq.Update(DATA_VIEW_TABLE_NAME).
+			SetMap(updateMap).
+			Where(sq.Eq{"f_view_id": view.ViewID}).
+			ToSql()
+		if err != nil {
+			return fmt.Errorf("generate update sql failed for view %s: %w", view.ViewID, err)
+		}
+
+		_, err = tx.Exec(sqlStr, args...)
+		if err != nil {
+			return fmt.Errorf("execute update failed for view %s: %w", view.ViewID, err)
+		}
 	}
 
 	span.SetStatus(codes.Ok, "")
@@ -724,6 +796,61 @@ func (dva *dataViewAccess) ListDataViews(ctx context.Context,
 	return views, nil
 }
 
+// 查询数据视图列表
+func (dva *dataViewAccess) ListDataViewsByDataSource(ctx context.Context, dataSourceID string) ([]*interfaces.ViewDeleteTime, error) {
+	ctx, span := ar_trace.Tracer.Start(ctx, "driven layer: List data views from DB",
+		trace.WithSpanKind(trace.SpanKindClient))
+	defer span.End()
+
+	views := make([]*interfaces.ViewDeleteTime, 0)
+
+	builder := sq.Select("f_view_id", "f_delete_time").From(DATA_VIEW_TABLE_NAME).
+		Where(sq.Eq{"f_data_source_id": dataSourceID})
+
+	sqlStr, args, err := builder.ToSql()
+	if err != nil {
+		errDetails := fmt.Sprintf("Generate 'list view' sql stmt failed, %s", err.Error())
+		logger.Error(errDetails)
+		o11y.Error(ctx, errDetails)
+		span.SetStatus(codes.Error, "Generate sql stmt failed")
+
+		return nil, err
+	}
+
+	sqlStmt := fmt.Sprintf("Sql stmt for listing views is '%s'", sqlStr)
+	logger.Debug(sqlStmt)
+	o11y.Info(ctx, sqlStmt)
+
+	rows, err := dva.db.Query(sqlStr, args...)
+	if err != nil {
+		errDetails := fmt.Sprintf("List data views failed, %s", err.Error())
+		logger.Error(errDetails)
+		o11y.Error(ctx, errDetails)
+		span.SetStatus(codes.Error, "List data views failed")
+
+		return nil, err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		viewDeleteTime := &interfaces.ViewDeleteTime{}
+		err := rows.Scan(&viewDeleteTime.ViewID, &viewDeleteTime.DeleteTime)
+		if err != nil {
+			errDetails := fmt.Sprintf("Row scan failed, err: %s", err.Error())
+			logger.Error(errDetails)
+			o11y.Error(ctx, errDetails)
+			span.SetStatus(codes.Error, "Row scan failed")
+
+			return nil, err
+		}
+
+		views = append(views, viewDeleteTime)
+	}
+
+	span.SetStatus(codes.Ok, "")
+	return views, nil
+}
+
 // 查询数据视图总数
 func (dva *dataViewAccess) GetDataViewsTotal(ctx context.Context,
 	query *interfaces.ListViewQueryParams) (int, error) {
@@ -866,6 +993,7 @@ func (dva *dataViewAccess) CheckDataViewExistByName(ctx context.Context, tx *sql
 		Where(sq.Eq{
 			"dv.f_view_name":   viewName,
 			"dvg.f_group_name": groupName,
+			"dv.f_delete_time": 0,
 		}).
 		ToSql()
 
@@ -929,6 +1057,7 @@ func (dva *dataViewAccess) CheckDataViewExistByTechnicalName(ctx context.Context
 		Where(sq.Eq{
 			"dv.f_technical_name": viewTechnicalName,
 			"dvg.f_group_name":    groupName,
+			"dv.f_delete_time":    0,
 		}).
 		ToSql()
 
@@ -1839,8 +1968,8 @@ func (dva *dataViewAccess) GetDataViewsByGroupID(ctx context.Context, groupID st
 	return views, nil
 }
 
-func (dva *dataViewAccess) GetDataViewsBySourceID(ctx context.Context, sourceID string) ([]*interfaces.DataView, error) {
-	ctx, span := ar_trace.Tracer.Start(ctx, "Select data views by data_source_id", trace.WithSpanKind(trace.SpanKindClient))
+func (dva *dataViewAccess) GetDataViewsBySourceID(ctx context.Context, sourceID string) ([]string, error) {
+	ctx, span := ar_trace.Tracer.Start(ctx, "Select data view IDs by data_source_id", trace.WithSpanKind(trace.SpanKindClient))
 	defer span.End()
 	span.SetAttributes(
 		attr.Key("db_url").String(libdb.GetDBUrl()),
@@ -1848,39 +1977,9 @@ func (dva *dataViewAccess) GetDataViewsBySourceID(ctx context.Context, sourceID 
 		attr.Key("data_source_id").String(sourceID),
 	)
 
-	sqlStr, args, err := sq.Select(
-		"dv.f_view_id",
-		"dv.f_view_name",
-		"dv.f_technical_name",
-		"dv.f_group_id",
-		"COALESCE(dvg.f_group_name, '')",
-		"dv.f_type",
-		"dv.f_query_type",
-		"dv.f_builtin",
-		"dv.f_tags",
-		"dv.f_comment",
-		"dv.f_data_source_type",
-		"dv.f_data_source_id",
-		"dv.f_file_name",
-		"dv.f_excel_config",
-		"dv.f_data_scope",
-		"dv.f_fields",
-		"dv.f_status",
-		"dv.f_metadata_form_id",
-		"dv.f_primary_keys",
-		"COALESCE(dv.f_sql, '')",
-		"dv.f_meta_table_name",
-		"dv.f_create_time",
-		"dv.f_update_time",
-		"dv.f_delete_time",
-		"dv.f_creator",
-		"dv.f_creator_type",
-		"dv.f_updater",
-		"dv.f_updater_type",
-	).
-		From(fmt.Sprintf("%s as dv", DATA_VIEW_TABLE_NAME)).
-		LeftJoin(fmt.Sprintf("%s as dvg on dv.f_group_id = dvg.f_group_id", DATA_VIEW_GROUP_TABLE_NAME)).
-		Where(sq.Eq{"dv.f_data_source_id": sourceID}).ToSql()
+	sqlStr, args, err := sq.Select("f_view_id").
+		From(DATA_VIEW_TABLE_NAME).
+		Where(sq.Eq{"f_data_source_id": sourceID}).ToSql()
 	if err != nil {
 		errDetails := fmt.Sprintf("Generate 'get views' sql stmt error: %s", err.Error())
 		logger.Error(errDetails)
@@ -1894,7 +1993,7 @@ func (dva *dataViewAccess) GetDataViewsBySourceID(ctx context.Context, sourceID 
 	logger.Debug(sqlStmt)
 	o11y.Info(ctx, sqlStmt)
 
-	views := []*interfaces.DataView{}
+	viewIDs := []string{}
 	rows, err := dva.db.Query(sqlStr, args...)
 	if err != nil {
 		errDetails := fmt.Sprintf("Query data views failed, %s", err.Error())
@@ -1907,41 +2006,9 @@ func (dva *dataViewAccess) GetDataViewsBySourceID(ctx context.Context, sourceID 
 	defer rows.Close()
 
 	for rows.Next() {
-		var tagsStr, primaryKeysStr string
-		var excelConfigBytes, dataScopeBytes, fieldsBytes []byte
-		view := &interfaces.DataView{
-			ModuleType: interfaces.MODULE_TYPE_DATA_VIEW,
-		}
-		err = rows.Scan(
-			&view.ViewID,
-			&view.ViewName,
-			&view.TechnicalName,
-			&view.GroupID,
-			&view.GroupName,
-			&view.Type,
-			&view.QueryType,
-			&view.Builtin,
-			&tagsStr,
-			&view.Comment,
-			&view.DataSourceType,
-			&view.DataSourceID,
-			&view.FileName,
-			&excelConfigBytes,
-			&dataScopeBytes,
-			&fieldsBytes,
-			&view.Status,
-			&view.MetadataFormID,
-			&primaryKeysStr,
-			&view.SQLStr,
-			&view.MetaTableName,
-			&view.CreateTime,
-			&view.UpdateTime,
-			&view.DeleteTime,
-			&view.Creator.ID,
-			&view.Creator.Type,
-			&view.Updater.ID,
-			&view.Updater.Type,
-		)
+
+		var viewID string
+		err = rows.Scan(&viewID)
 		if err != nil {
 			errDetails := fmt.Sprintf("Row scan failed, error: %s", err.Error())
 			logger.Error(errDetails)
@@ -1951,69 +2018,9 @@ func (dva *dataViewAccess) GetDataViewsBySourceID(ctx context.Context, sourceID 
 			return nil, err
 		}
 
-		view.Tags = libCommon.TagString2TagSlice(tagsStr)
-		view.PrimaryKeys = libCommon.TagString2TagSlice(primaryKeysStr)
-
-		// 反序列化
-		// err := sonic.Unmarshal([]byte(dataSourceBytes), &view.DataSource)
-		// if err != nil {
-		// 	errDetails := fmt.Sprintf("Unmarshal dataSource failed, %s", err.Error())
-		// 	logger.Error(errDetails)
-		// 	o11y.Error(ctx, errDetails)
-		// 	span.SetStatus(codes.Error, "Unmarshal dataSource failed")
-
-		// 	return nil, err
-		// }
-
-		if len(excelConfigBytes) != 0 {
-			err := sonic.Unmarshal([]byte(excelConfigBytes), &view.ExcelConfig)
-			if err != nil {
-				errDetails := fmt.Sprintf("Unmarshal dataSource failed, %s", err.Error())
-				logger.Error(errDetails)
-				o11y.Error(ctx, errDetails)
-				span.SetStatus(codes.Error, "Unmarshal dataSource failed")
-
-				return nil, err
-			}
-		}
-
-		if len(dataScopeBytes) != 0 {
-			err = sonic.Unmarshal([]byte(dataScopeBytes), &view.DataScope)
-			if err != nil {
-				errDetails := fmt.Sprintf("Unmarshal dataSource failed, %s", err.Error())
-				logger.Error(errDetails)
-				o11y.Error(ctx, errDetails)
-				span.SetStatus(codes.Error, "Unmarshal dataSource failed")
-
-				return nil, err
-			}
-		}
-
-		if len(fieldsBytes) != 0 {
-			err = sonic.Unmarshal([]byte(fieldsBytes), &view.Fields)
-			if err != nil {
-				errDetails := fmt.Sprintf("Unmarshal fields failed, %s", err.Error())
-				logger.Error(errDetails)
-				o11y.Error(ctx, errDetails)
-				span.SetStatus(codes.Error, "Unmarshal fields failed")
-
-				return nil, err
-			}
-		}
-
-		// err = sonic.Unmarshal([]byte(condBytes), &view.Condition)
-		// if err != nil {
-		// 	errDetails := fmt.Sprintf("Unmarshal condition failed, %s", err.Error())
-		// 	logger.Error(errDetails)
-		// 	o11y.Error(ctx, errDetails)
-		// 	span.SetStatus(codes.Error, "Unmarshal condition failed")
-
-		// 	return nil, err
-		// }
-
-		views = append(views, view)
+		viewIDs = append(viewIDs, viewID)
 	}
 
 	span.SetStatus(codes.Ok, "")
-	return views, nil
+	return viewIDs, nil
 }

--- a/vega/mdl-data-model/server/drivenadapters/data_view/data_view_group_access.go
+++ b/vega/mdl-data-model/server/drivenadapters/data_view/data_view_group_access.go
@@ -222,6 +222,7 @@ func (dvga *dataViewGroupAccess) ListDataViewGroups(ctx context.Context, params 
 		"f_group_name",
 		"f_create_time",
 		"f_update_time",
+		"f_delete_time",
 		"f_builtin").
 		From(DATA_VIEW_GROUP_TABLE_NAME)
 		// JoinClause(subquery.Prefix(" LEFT JOIN (").Suffix(") AS dv ON (dvg.f_group_id = dv.f_group_id)"))
@@ -270,6 +271,7 @@ func (dvga *dataViewGroupAccess) ListDataViewGroups(ctx context.Context, params 
 			&dataViewGroup.GroupName,
 			&dataViewGroup.CreateTime,
 			&dataViewGroup.UpdateTime,
+			&dataViewGroup.DeleteTime,
 			&dataViewGroup.Builtin,
 		)
 		if err != nil {
@@ -423,8 +425,9 @@ func (dvga *dataViewGroupAccess) CheckDataViewGroupExistByName(ctx context.Conte
 		"f_builtin").
 		From(DATA_VIEW_GROUP_TABLE_NAME).
 		Where(sq.Eq{
-			"f_group_name": groupName,
-			"f_builtin":    builtin,
+			"f_group_name":  groupName,
+			"f_builtin":     builtin,
+			"f_delete_time": 0,
 		}).
 		ToSql()
 

--- a/vega/mdl-data-model/server/drivenadapters/data_view/data_view_group_access_test.go
+++ b/vega/mdl-data-model/server/drivenadapters/data_view/data_view_group_access_test.go
@@ -203,6 +203,8 @@ func Test_DataViewGroupAccess_ListDataViewsGroup(t *testing.T) {
 			GroupName:  "x",
 			CreateTime: testNow,
 			UpdateTime: testNow,
+			DeleteTime: 0,
+			Builtin:    true,
 		}
 
 		rows1 := sqlmock.NewRows([]string{
@@ -210,12 +212,14 @@ func Test_DataViewGroupAccess_ListDataViewsGroup(t *testing.T) {
 			"f_group_name",
 			"f_create_time",
 			"f_update_time",
+			"f_delete_time",
 			"f_builtin",
 		}).AddRow(
 			group.GroupID,
 			group.GroupName,
 			group.CreateTime,
 			group.UpdateTime,
+			group.DeleteTime,
 			false,
 		)
 		rows2 := sqlmock.NewRows([]string{
@@ -223,23 +227,26 @@ func Test_DataViewGroupAccess_ListDataViewsGroup(t *testing.T) {
 			"f_group_name",
 			"f_create_time",
 			"f_update_time",
+			"f_delete_time",
 			"f_builtin",
 		}).AddRow(
 			group.GroupID,
 			group.GroupName,
 			group.CreateTime,
 			group.UpdateTime,
+			group.DeleteTime,
 			true,
 		).AddRow(
 			group.GroupID,
 			group.GroupName,
 			group.CreateTime,
 			group.UpdateTime,
+			group.DeleteTime,
 			false,
 		)
 
 		sqlStr := fmt.Sprintf("SELECT f_group_id, f_group_name, f_create_time, "+
-			"f_update_time, f_builtin FROM %s WHERE f_builtin IN (?) AND f_delete_time = ? "+
+			"f_update_time, f_delete_time, f_builtin FROM %s WHERE f_builtin IN (?) AND f_delete_time = ? "+
 			"ORDER BY f_update_time desc LIMIT 1000 OFFSET 0", DATA_VIEW_GROUP_TABLE_NAME)
 
 		listQuery := &interfaces.ListViewGroupQueryParams{
@@ -292,7 +299,7 @@ func Test_DataViewGroupAccess_ListDataViewsGroup(t *testing.T) {
 
 		Convey("List succeed with limit is equal to 1", func() {
 			sqlStr := fmt.Sprintf("SELECT f_group_id, f_group_name, f_create_time, "+
-				"f_update_time, f_builtin FROM %s WHERE f_builtin IN (?) AND f_delete_time = ? "+
+				"f_update_time, f_delete_time, f_builtin FROM %s WHERE f_builtin IN (?) AND f_delete_time = ? "+
 				"ORDER BY f_update_time desc LIMIT 1 OFFSET 0", DATA_VIEW_GROUP_TABLE_NAME)
 
 			listQuery.Limit = 1
@@ -309,7 +316,7 @@ func Test_DataViewGroupAccess_ListDataViewsGroup(t *testing.T) {
 
 		Convey("List succeed with no limit", func() {
 			sqlStr := fmt.Sprintf("SELECT f_group_id, f_group_name, f_create_time, "+
-				"f_update_time, f_builtin FROM %s WHERE f_builtin IN (?) AND f_delete_time = ? "+
+				"f_update_time, f_delete_time, f_builtin FROM %s WHERE f_builtin IN (?) AND f_delete_time = ? "+
 				"ORDER BY f_update_time desc", DATA_VIEW_GROUP_TABLE_NAME)
 
 			smock.ExpectQuery(sqlStr).WithArgs().WillReturnRows(rows2)
@@ -464,7 +471,7 @@ func Test_DataViewGroupAccess_CheckDataViewGroupExistByName(t *testing.T) {
 
 		rows := sqlmock.NewRows([]string{"f_group_id", "f_builtin"}).AddRow(views[0].GroupID, views[0].Builtin)
 
-		sqlStr := fmt.Sprintf("SELECT f_group_id, f_builtin FROM %s WHERE f_builtin = ? AND f_group_name = ?", DATA_VIEW_GROUP_TABLE_NAME)
+		sqlStr := fmt.Sprintf("SELECT f_group_id, f_builtin FROM %s WHERE f_builtin = ? AND f_delete_time = ? AND f_group_name = ?", DATA_VIEW_GROUP_TABLE_NAME)
 
 		group := &interfaces.DataViewGroup{
 			GroupID:    "x",

--- a/vega/mdl-data-model/server/drivenadapters/permission/permission_access.go
+++ b/vega/mdl-data-model/server/drivenadapters/permission/permission_access.go
@@ -332,7 +332,7 @@ func (pa *permissionAccess) FilterResources(ctx context.Context,
 
 	filter.Method = http.MethodGet
 	respCode, result, err := pa.httpClient.PostNoUnmarshal(ctx, httpUrl, headers, filter)
-	logger.Debugf("post [%s] finished, response code is [%d], result is [%s], error is [%v]", httpUrl, respCode, result, err)
+	logger.Debugf("post [%s] finished, response code is [%d], error is [%v]", httpUrl, respCode, err)
 
 	if err != nil {
 		logger.Errorf("Post resource-filter request failed: %v", err)

--- a/vega/mdl-data-model/server/drivenadapters/vega/vega_metadata_access.go
+++ b/vega/mdl-data-model/server/drivenadapters/vega/vega_metadata_access.go
@@ -165,7 +165,7 @@ func (vma *vegaMetadataAccess) GetMetadataTablesByIDs(ctx context.Context, table
 	}
 
 	respCode, respData, err := vma.httpClient.PostNoUnmarshal(ctx, urlStr, headers, requestBody)
-	logger.Debugf("get %s finished, response code is %d, request body is %+v, error is %v", urlStr, respCode, requestBody, err)
+	logger.Debugf("get %s finished, response code is %d, error is %v", urlStr, respCode, err)
 
 	if err != nil {
 		logger.Errorf("DrivenMetadata GetMetadataTablesByIDs request failed: %v", err)

--- a/vega/mdl-data-model/server/driveradapters/validate_data_view.go
+++ b/vega/mdl-data-model/server/driveradapters/validate_data_view.go
@@ -398,6 +398,7 @@ func validateViewFields(ctx context.Context, viewFields []*interfaces.ViewField)
 func validateFeatures(ctx context.Context, fieldsMap map[string]*interfaces.ViewField, features []interfaces.FieldFeature) error {
 	enabledMap := make(map[interfaces.FieldFeatureType]bool)
 	featureNameMap := make(map[string]struct{})
+	featureFingerprintMap := make(map[string]struct{})
 	for _, f := range features {
 		if f.FeatureName == "" {
 			return rest.NewHTTPError(ctx, http.StatusBadRequest, derrors.DataModel_DataView_InvalidParameter_FieldFeatureName).
@@ -425,6 +426,16 @@ func validateFeatures(ctx context.Context, fieldsMap map[string]*interfaces.View
 		if _, ok := interfaces.FieldFeatureTypeMap[f.FeatureType]; !ok {
 			return rest.NewHTTPError(ctx, http.StatusBadRequest, rest.PublicError_BadRequest).
 				WithErrorDetails("The field feature type is invalid")
+		}
+
+		// 指纹：Type + RefField
+		fingerprint := fmt.Sprintf("%s|%s", f.FeatureType, f.RefField)
+		if _, ok := featureFingerprintMap[fingerprint]; !ok {
+			featureFingerprintMap[fingerprint] = struct{}{}
+		} else {
+			errDetails := fmt.Sprintf("Data view field feature '%s' fingerprint '%s' already exists", f.FeatureName, fingerprint)
+			return rest.NewHTTPError(ctx, http.StatusBadRequest, rest.PublicError_BadRequest).
+				WithErrorDetails(errDetails)
 		}
 
 		// 校验特征备注，长度限制1000

--- a/vega/mdl-data-model/server/interfaces/data_view_access.go
+++ b/vega/mdl-data-model/server/interfaces/data_view_access.go
@@ -266,6 +266,7 @@ type DataViewAccess interface {
 	CreateDataViews(ctx context.Context, tx *sql.Tx, views []*DataView) error
 	DeleteDataViews(ctx context.Context, tx *sql.Tx, viewIDs []string) error
 	UpdateDataView(ctx context.Context, tx *sql.Tx, view *DataView) error
+	UpdateDataViews(ctx context.Context, tx *sql.Tx, views []*DataView) error
 	GetDataViews(ctx context.Context, viewID []string) ([]*DataView, error)
 	ListDataViews(ctx context.Context, viewsQuery *ListViewQueryParams) ([]*SimpleDataView, error)
 	GetDataViewsTotal(ctx context.Context, viewsQuery *ListViewQueryParams) (int, error)
@@ -293,8 +294,9 @@ type DataViewAccess interface {
 	GetDataViewsByGroupID(ctx context.Context, groupID string) ([]*DataView, error)
 
 	// 根据数据源id获取视图
-	GetDataViewsBySourceID(ctx context.Context, sourceID string) ([]*DataView, error)
+	GetDataViewsBySourceID(ctx context.Context, sourceID string) ([]string, error)
 
 	// 批量标记删除视图
 	MarkDataViewsDeleted(ctx context.Context, tx *sql.Tx, params *MarkViewDeletedParams) error
+	ListDataViewsByDataSource(ctx context.Context, dataSourceID string) ([]*ViewDeleteTime, error)
 }

--- a/vega/mdl-data-model/server/interfaces/data_view_monitor_service.go
+++ b/vega/mdl-data-model/server/interfaces/data_view_monitor_service.go
@@ -25,17 +25,16 @@ type SyncResult struct {
 
 // BatchResult 批次处理结果
 type BatchResult struct {
-	BatchID               int          `json:"batch_id"`                 // 批次ID
-	TotalMetaTableCount   int          `json:"total_meta_table_count"`   // 总元数据表数量
-	InvalidMetaTableCount int          `json:"invalid_meta_table_count"` // 无效元数据表数量
-	TotalCount            int          `json:"total_count"`              // 总处理数量
-	SuccessCount          int          `json:"success_count"`            // 成功处理数量
-	NeedCreatedCount      int          `json:"need_created_count"`       // 待创建视图数量
-	NeedUpdatedCount      int          `json:"need_updated_count"`       // 待更新视图数量
-	ErrorCount            int          `json:"error_count"`              // 错误数量
-	StartTime             time.Time    `json:"start_time"`               // 开始时间
-	EndTime               time.Time    `json:"end_time"`                 // 结束时间
-	Results               []SyncResult `json:"results"`                  // 同步结果列表
+	BatchID               int       `json:"batch_id"`                 // 批次ID
+	TotalMetaTableCount   int       `json:"total_meta_table_count"`   // 总元数据表数量
+	InvalidMetaTableCount int       `json:"invalid_meta_table_count"` // 无效元数据表数量
+	TotalCount            int       `json:"total_count"`              // 总处理数量
+	SuccessCount          int       `json:"success_count"`            // 成功处理数量
+	NeedCreatedCount      int       `json:"need_created_count"`       // 待创建视图数量
+	NeedUpdatedCount      int       `json:"need_updated_count"`       // 待更新视图数量
+	ErrorCount            int       `json:"error_count"`              // 错误数量
+	StartTime             time.Time `json:"start_time"`               // 开始时间
+	EndTime               time.Time `json:"end_time"`                 // 结束时间
 }
 
 //go:generate mockgen -source ../interfaces/data_view_monitor_service.go -destination ../interfaces/mock/mock_data_view_monitor_service.go

--- a/vega/mdl-data-model/server/interfaces/data_view_service.go
+++ b/vega/mdl-data-model/server/interfaces/data_view_service.go
@@ -168,6 +168,11 @@ type ViewIDsReq struct {
 	IDs []string `json:"view_ids"`
 }
 
+type ViewDeleteTime struct {
+	ViewID     string
+	DeleteTime int64
+}
+
 //go:generate mockgen -source ../interfaces/data_view_service.go -destination ../interfaces/mock/mock_data_view_service.go
 type DataViewService interface {
 	CreateDataViews(ctx context.Context, dataViews []*DataView, mode string, checkPermission bool) ([]string, error)
@@ -186,16 +191,19 @@ type DataViewService interface {
 	RetriveGroupIDByGroupName(ctx context.Context, tx *sql.Tx, viewGroupReq *ViewGroupReq) (string, bool, error)
 	UpdateDataViewsGroup(ctx context.Context, views map[string]*DataView, group *ViewGroupReq) error
 	UpdateAtomicDataViews(ctx context.Context, attrs *AtomicViewUpdateReq) error
-	// UpdateDataViewRealTimeStreaming(ctx context.Context, realTimeStreaming *RealTimeStreaming) error
 
 	// 导出分组下的视图
 	GetDataViewsByGroupID(ctx context.Context, groupID string) ([]*DataView, error)
-	GetDataViewsBySourceID(ctx context.Context, sourceID string) ([]*DataView, error)
+	GetDataViewIDsBySourceID(ctx context.Context, sourceID string) ([]string, error)
 
 	// 获取数据视图的资源实例列表
 	ListDataViewSrcs(ctx context.Context, params *ListViewQueryParams) ([]PermissionResource, int, error)
 
-	UpdateDataViewInternal(ctx context.Context, view *DataView) error
+	UpdateDataViewsInternal(ctx context.Context, views []*DataView) error
+	CreateDataViewsInternal(ctx context.Context, views []*DataView) error
+	GetDataViewsInternal(ctx context.Context, viewIDs []string) ([]*DataView, error)
+	ListDataViewsByDataSource(ctx context.Context, dataSourceID string) ([]*ViewDeleteTime, error)
+
 	// 批量标记删除视图
 	MarkDataViewsDeleted(ctx context.Context, tx *sql.Tx, viewIDs []string) error
 }

--- a/vega/mdl-data-model/server/interfaces/mock/mock_data_view_access.go
+++ b/vega/mdl-data-model/server/interfaces/mock/mock_data_view_access.go
@@ -149,10 +149,10 @@ func (mr *MockDataViewAccessMockRecorder) GetDataViewsByGroupID(ctx, groupID any
 }
 
 // GetDataViewsBySourceID mocks base method.
-func (m *MockDataViewAccess) GetDataViewsBySourceID(ctx context.Context, sourceID string) ([]*interfaces.DataView, error) {
+func (m *MockDataViewAccess) GetDataViewsBySourceID(ctx context.Context, sourceID string) ([]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetDataViewsBySourceID", ctx, sourceID)
-	ret0, _ := ret[0].([]*interfaces.DataView)
+	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -253,6 +253,21 @@ func (mr *MockDataViewAccessMockRecorder) ListDataViews(ctx, viewsQuery any) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListDataViews", reflect.TypeOf((*MockDataViewAccess)(nil).ListDataViews), ctx, viewsQuery)
 }
 
+// ListDataViewsByDataSource mocks base method.
+func (m *MockDataViewAccess) ListDataViewsByDataSource(ctx context.Context, dataSourceID string) ([]*interfaces.ViewDeleteTime, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListDataViewsByDataSource", ctx, dataSourceID)
+	ret0, _ := ret[0].([]*interfaces.ViewDeleteTime)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListDataViewsByDataSource indicates an expected call of ListDataViewsByDataSource.
+func (mr *MockDataViewAccessMockRecorder) ListDataViewsByDataSource(ctx, dataSourceID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListDataViewsByDataSource", reflect.TypeOf((*MockDataViewAccess)(nil).ListDataViewsByDataSource), ctx, dataSourceID)
+}
+
 // MarkDataViewsDeleted mocks base method.
 func (m *MockDataViewAccess) MarkDataViewsDeleted(ctx context.Context, tx *sql.Tx, params *interfaces.MarkViewDeletedParams) error {
 	m.ctrl.T.Helper()
@@ -293,6 +308,20 @@ func (m *MockDataViewAccess) UpdateDataViewRealTimeStreaming(ctx context.Context
 func (mr *MockDataViewAccessMockRecorder) UpdateDataViewRealTimeStreaming(ctx, tx, realTimeStreaming any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateDataViewRealTimeStreaming", reflect.TypeOf((*MockDataViewAccess)(nil).UpdateDataViewRealTimeStreaming), ctx, tx, realTimeStreaming)
+}
+
+// UpdateDataViews mocks base method.
+func (m *MockDataViewAccess) UpdateDataViews(ctx context.Context, tx *sql.Tx, views []*interfaces.DataView) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateDataViews", ctx, tx, views)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateDataViews indicates an expected call of UpdateDataViews.
+func (mr *MockDataViewAccessMockRecorder) UpdateDataViews(ctx, tx, views any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateDataViews", reflect.TypeOf((*MockDataViewAccess)(nil).UpdateDataViews), ctx, tx, views)
 }
 
 // UpdateDataViewsAttrs mocks base method.

--- a/vega/mdl-data-model/server/interfaces/mock/mock_data_view_service.go
+++ b/vega/mdl-data-model/server/interfaces/mock/mock_data_view_service.go
@@ -89,6 +89,20 @@ func (mr *MockDataViewServiceMockRecorder) CreateDataViews(ctx, dataViews, mode,
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateDataViews", reflect.TypeOf((*MockDataViewService)(nil).CreateDataViews), ctx, dataViews, mode, checkPermission)
 }
 
+// CreateDataViewsInternal mocks base method.
+func (m *MockDataViewService) CreateDataViewsInternal(ctx context.Context, views []*interfaces.DataView) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateDataViewsInternal", ctx, views)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CreateDataViewsInternal indicates an expected call of CreateDataViewsInternal.
+func (mr *MockDataViewServiceMockRecorder) CreateDataViewsInternal(ctx, views any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateDataViewsInternal", reflect.TypeOf((*MockDataViewService)(nil).CreateDataViewsInternal), ctx, views)
+}
+
 // DeleteDataViews mocks base method.
 func (m *MockDataViewService) DeleteDataViews(ctx context.Context, viewIDs []string) error {
 	m.ctrl.T.Helper()
@@ -116,6 +130,21 @@ func (m *MockDataViewService) GetDataView(ctx context.Context, viewID string) (*
 func (mr *MockDataViewServiceMockRecorder) GetDataView(ctx, viewID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDataView", reflect.TypeOf((*MockDataViewService)(nil).GetDataView), ctx, viewID)
+}
+
+// GetDataViewIDsBySourceID mocks base method.
+func (m *MockDataViewService) GetDataViewIDsBySourceID(ctx context.Context, sourceID string) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDataViewIDsBySourceID", ctx, sourceID)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetDataViewIDsBySourceID indicates an expected call of GetDataViewIDsBySourceID.
+func (mr *MockDataViewServiceMockRecorder) GetDataViewIDsBySourceID(ctx, sourceID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDataViewIDsBySourceID", reflect.TypeOf((*MockDataViewService)(nil).GetDataViewIDsBySourceID), ctx, sourceID)
 }
 
 // GetDataViews mocks base method.
@@ -148,19 +177,19 @@ func (mr *MockDataViewServiceMockRecorder) GetDataViewsByGroupID(ctx, groupID an
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDataViewsByGroupID", reflect.TypeOf((*MockDataViewService)(nil).GetDataViewsByGroupID), ctx, groupID)
 }
 
-// GetDataViewsBySourceID mocks base method.
-func (m *MockDataViewService) GetDataViewsBySourceID(ctx context.Context, sourceID string) ([]*interfaces.DataView, error) {
+// GetDataViewsInternal mocks base method.
+func (m *MockDataViewService) GetDataViewsInternal(ctx context.Context, viewIDs []string) ([]*interfaces.DataView, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetDataViewsBySourceID", ctx, sourceID)
+	ret := m.ctrl.Call(m, "GetDataViewsInternal", ctx, viewIDs)
 	ret0, _ := ret[0].([]*interfaces.DataView)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetDataViewsBySourceID indicates an expected call of GetDataViewsBySourceID.
-func (mr *MockDataViewServiceMockRecorder) GetDataViewsBySourceID(ctx, sourceID any) *gomock.Call {
+// GetDataViewsInternal indicates an expected call of GetDataViewsInternal.
+func (mr *MockDataViewServiceMockRecorder) GetDataViewsInternal(ctx, viewIDs any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDataViewsBySourceID", reflect.TypeOf((*MockDataViewService)(nil).GetDataViewsBySourceID), ctx, sourceID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDataViewsInternal", reflect.TypeOf((*MockDataViewService)(nil).GetDataViewsInternal), ctx, viewIDs)
 }
 
 // GetDetailedDataViewMapByIDs mocks base method.
@@ -225,6 +254,21 @@ func (mr *MockDataViewServiceMockRecorder) ListDataViews(ctx, params any) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListDataViews", reflect.TypeOf((*MockDataViewService)(nil).ListDataViews), ctx, params)
 }
 
+// ListDataViewsByDataSource mocks base method.
+func (m *MockDataViewService) ListDataViewsByDataSource(ctx context.Context, dataSourceID string) ([]*interfaces.ViewDeleteTime, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListDataViewsByDataSource", ctx, dataSourceID)
+	ret0, _ := ret[0].([]*interfaces.ViewDeleteTime)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListDataViewsByDataSource indicates an expected call of ListDataViewsByDataSource.
+func (mr *MockDataViewServiceMockRecorder) ListDataViewsByDataSource(ctx, dataSourceID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListDataViewsByDataSource", reflect.TypeOf((*MockDataViewService)(nil).ListDataViewsByDataSource), ctx, dataSourceID)
+}
+
 // MarkDataViewsDeleted mocks base method.
 func (m *MockDataViewService) MarkDataViewsDeleted(ctx context.Context, tx *sql.Tx, viewIDs []string) error {
 	m.ctrl.T.Helper()
@@ -283,20 +327,6 @@ func (mr *MockDataViewServiceMockRecorder) UpdateDataView(ctx, tx, dataView any)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateDataView", reflect.TypeOf((*MockDataViewService)(nil).UpdateDataView), ctx, tx, dataView)
 }
 
-// UpdateDataViewInternal mocks base method.
-func (m *MockDataViewService) UpdateDataViewInternal(ctx context.Context, view *interfaces.DataView) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateDataViewInternal", ctx, view)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// UpdateDataViewInternal indicates an expected call of UpdateDataViewInternal.
-func (mr *MockDataViewServiceMockRecorder) UpdateDataViewInternal(ctx, view any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateDataViewInternal", reflect.TypeOf((*MockDataViewService)(nil).UpdateDataViewInternal), ctx, view)
-}
-
 // UpdateDataViewsGroup mocks base method.
 func (m *MockDataViewService) UpdateDataViewsGroup(ctx context.Context, views map[string]*interfaces.DataView, group *interfaces.ViewGroupReq) error {
 	m.ctrl.T.Helper()
@@ -309,4 +339,18 @@ func (m *MockDataViewService) UpdateDataViewsGroup(ctx context.Context, views ma
 func (mr *MockDataViewServiceMockRecorder) UpdateDataViewsGroup(ctx, views, group any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateDataViewsGroup", reflect.TypeOf((*MockDataViewService)(nil).UpdateDataViewsGroup), ctx, views, group)
+}
+
+// UpdateDataViewsInternal mocks base method.
+func (m *MockDataViewService) UpdateDataViewsInternal(ctx context.Context, views []*interfaces.DataView) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateDataViewsInternal", ctx, views)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateDataViewsInternal indicates an expected call of UpdateDataViewsInternal.
+func (mr *MockDataViewServiceMockRecorder) UpdateDataViewsInternal(ctx, views any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateDataViewsInternal", reflect.TypeOf((*MockDataViewService)(nil).UpdateDataViewsInternal), ctx, views)
 }

--- a/vega/mdl-data-model/server/logics/data_view/data_view_service.go
+++ b/vega/mdl-data-model/server/logics/data_view/data_view_service.go
@@ -476,167 +476,149 @@ func (dvs *dataViewService) UpdateDataView(ctx context.Context, tx *sql.Tx, view
 	return nil
 }
 
-// 内部修改单个数据视图，不校验权限, 同步库表为原子视图时使用
-func (dvs *dataViewService) UpdateDataViewInternal(ctx context.Context, view *interfaces.DataView) error {
-	ctx, span := ar_trace.Tracer.Start(ctx, "logic layer: Update a data view internal")
+// UpdateDataViewsInternal 批量修改数据视图内部逻辑
+func (dvs *dataViewService) UpdateDataViewsInternal(ctx context.Context, views []*interfaces.DataView) error {
+	ctx, span := ar_trace.Tracer.Start(ctx, "logic layer: Batch update data views")
 	defer span.End()
 
-	// 从数据库查询旧的视图信息
-	oldViews, err := dvs.dva.GetDataViews(ctx, []string{view.ViewID})
-	if err != nil {
-		logger.Errorf("GetDataViews error: %s", err.Error())
-		span.SetStatus(codes.Error, "GetDataViews failed")
-		return rest.NewHTTPError(ctx, http.StatusInternalServerError,
-			derrors.DataModel_DataView_InternalError_GetDataViewsFailed).WithErrorDetails(err.Error())
-	}
-
-	if len(oldViews) == 0 {
-		// 不报错，如果同步过程中更新视图时，用户手动删除了视图，直接跳过当前视图的更新
-		span.SetStatus(codes.Error, "Data view not found")
-		logger.Warnf("Update data view id '%s' name '%s' not found, skip", view.ViewID, view.ViewName)
+	if len(views) == 0 {
 		return nil
-		// return rest.NewHTTPError(ctx, http.StatusNotFound, derrors.DataModel_DataView_DataViewNotFound).
-		// 	WithErrorDetails(fmt.Sprintf("Data view '%s' does not exist", view.ViewID))
 	}
-	oldView := oldViews[0]
+	span.SetAttributes(attr.Key("view_count").Int(len(views)))
 
-	// 原子视图不支持修改分组名称
-	if oldView.Type == interfaces.ViewType_Atomic {
-		if view.GroupName != oldView.GroupName {
-			span.SetStatus(codes.Error, "Atomic data view cannot change group")
-			return rest.NewHTTPError(ctx, http.StatusNotFound, rest.PublicError_BadRequest).
-				WithErrorDetails(fmt.Sprintf("Atomic data view '%s' cannot change group", view.ViewID))
-		}
+	// 1. 批量获取旧视图
+	viewIDs := make([]string, len(views))
+	for i, v := range views {
+		viewIDs[i] = v.ViewID
 	}
-
-	// 检查索引库是否存在，字段类型是否冲突
-	httpErr := dvs.commonForCreateAndUpdate(ctx, view)
-	if httpErr != nil {
-		span.SetStatus(codes.Error, "Common operation for creating and updating failed")
-		return httpErr
+	oldViews, err := dvs.dva.GetDataViews(ctx, viewIDs)
+	if err != nil {
+		return rest.NewHTTPError(ctx, http.StatusInternalServerError, derrors.DataModel_DataView_InternalError_GetDataViewsFailed).
+			WithErrorDetails(err.Error())
+	}
+	oldViewMap := make(map[string]*interfaces.DataView, len(oldViews))
+	for _, ov := range oldViews {
+		oldViewMap[ov.ViewID] = ov
 	}
 
-	// accountInfo := interfaces.AccountInfo{}
-	// if ctx.Value(interfaces.ACCOUNT_INFO_KEY) != nil {
-	// 	accountInfo = ctx.Value(interfaces.ACCOUNT_INFO_KEY).(interfaces.AccountInfo)
-	// }
-	// 同步库表到原子视图时，如果是更新视图，不改变视图的更新者
-	view.Updater = oldView.Updater
-	view.UpdateTime = time.Now().UnixMilli()
-
-	needRollback := false
-	// 使用数据库事务
+	// 2. 开启事务
 	tx, err := dvs.db.Begin()
 	if err != nil {
-		logger.Errorf("UpdateDataView begin DB transaction failed: %s", err.Error())
-		span.SetStatus(codes.Error, "UpdateDataView begin DB transaction failed")
 		return rest.NewHTTPError(ctx, http.StatusInternalServerError, derrors.DataModel_DataView_InternalError_BeginDbTransactionFailed).
 			WithErrorDetails(err.Error())
 	}
-
+	needRollback := true
 	defer func() {
-		if !needRollback {
-			err = tx.Commit()
-			if err != nil {
-				span.SetStatus(codes.Error, "UpdateDataView commit DB transaction failed")
-				logger.Errorf("UpdateDataView commit DB transaction failed: %s", err.Error())
-			}
-		} else {
-			err = tx.Rollback()
-			if err != nil {
-				span.SetStatus(codes.Error, "UpdateDataView rollback DB transaction failed")
-				logger.Errorf("UpdateDataView rollback DB transaction failed: %s", err.Error())
+		if needRollback {
+			if rbErr := tx.Rollback(); rbErr != nil {
+				logger.Errorf("failed to rollback transaction: %v", rbErr)
 			}
 		}
 	}()
 
-	// 获取分组ID，如果分组不存在，则创建分组
-	groupID, isBuilitinGroup, httpErr := dvs.RetriveGroupIDByGroupName(ctx, tx, initViewGroupReq(view))
-	if httpErr != nil {
-		needRollback = true
-		logger.Errorf(fmt.Sprintf("Retrive group id by group name %s failed", view.GroupName))
-		span.SetStatus(codes.Error, "Retrive group id by group name failed")
-		return httpErr
-	}
+	// 3. 循环处理与单视图校验
+	filteredViews := make([]*interfaces.DataView, 0, len(views))
+	needResetStatusViewIDs := make([]string, 0)
+	now := time.Now().UnixMilli()
 
-	// 内置视图使用内置分组，非内置视图使用非内置分组
-	if oldView.Builtin != isBuilitinGroup {
-		needRollback = true
-		errDetails := "Built-in views must use built-in groups, non-built-in views must use non-built-in groups"
-		logger.Error(errDetails)
-		span.SetStatus(codes.Error, errDetails)
-		return rest.NewHTTPError(ctx, http.StatusForbidden, derrors.DataModel_DataView_InvalidBuiltinGroupMatch).
-			WithErrorDetails(errDetails)
-	}
+	for _, view := range views {
+		oldView, ok := oldViewMap[view.ViewID]
+		if !ok {
+			logger.Warnf("[UpdateDataViewsInternal] view id '%s' not found, skip", view.ViewID)
+			continue
+		}
 
-	// 更新视图的分组ID
-	view.GroupID = groupID
-
-	oldGroupID := oldView.GroupID
-	oldViewName := oldView.ViewName
-	newGroupID := groupID
-	newViewName := view.ViewName
-
-	// 校验视图名称在分组内是否已存在
-	if newGroupID != oldGroupID || newViewName != oldViewName {
-		_, exist, httpErr := dvs.CheckDataViewExistByName(ctx, tx, view.ViewName, view.GroupName)
-		if httpErr != nil {
-			needRollback = true
-			span.SetStatus(codes.Error, "Check data view exist by name failed")
+		// 核心约束校验与填充
+		if httpErr := dvs.prepareAndViewCheck(ctx, tx, view, oldView, now); httpErr != nil {
 			return httpErr
 		}
 
-		if exist {
-			needRollback = true
-			errDetails := fmt.Sprintf("Data view '%s' already exists in group '%s'", view.ViewName, view.GroupName)
-			logger.Errorf(errDetails)
-			span.SetStatus(codes.Error, errDetails)
-			return rest.NewHTTPError(ctx, http.StatusForbidden, derrors.DataModel_DataView_Existed_ViewName).
-				WithDescription(map[string]any{"ViewName": view.ViewName, "GroupName": view.GroupName}).
-				WithErrorDetails(errDetails)
+		// 标记需要恢复状态的视图 (DeleteTime > 0 表示该视图曾被软删除)
+		if oldView.DeleteTime > 0 {
+			needResetStatusViewIDs = append(needResetStatusViewIDs, view.ViewID)
 		}
+		filteredViews = append(filteredViews, view)
 	}
 
-	// 更新数据库的视图信息
-	err = dvs.dva.UpdateDataView(ctx, tx, view)
-	if err != nil {
-		needRollback = true
-		logger.Errorf("Update a data view error: %s", err.Error())
-		span.SetStatus(codes.Error, "Update a data view failed")
-		return rest.NewHTTPError(ctx, http.StatusInternalServerError,
-			derrors.DataModel_DataView_InternalError_UpdateDataViewFailed).WithErrorDetails(err.Error())
+	if len(filteredViews) == 0 {
+		return nil
 	}
 
-	// 对于删了源表又重新创建的视图，需要更新视图的状态为正常
-	if oldView.DeleteTime > 0 {
-		// 更新数据库的视图信息
-		err = dvs.dva.UpdateViewStatus(ctx, tx, []string{view.ViewID}, &interfaces.UpdateViewStatus{
+	// 4. 批量执行数据库更新
+	if err := dvs.dva.UpdateDataViews(ctx, tx, filteredViews); err != nil {
+		return rest.NewHTTPError(ctx, http.StatusInternalServerError, derrors.DataModel_DataView_InternalError_UpdateDataViewFailed).
+			WithErrorDetails(err.Error())
+	}
+
+	if len(needResetStatusViewIDs) > 0 {
+		err := dvs.dva.UpdateViewStatus(ctx, tx, needResetStatusViewIDs, &interfaces.UpdateViewStatus{
 			ViewStatus: interfaces.ViewScanStatus_New,
 			DeleteTime: 0,
 		})
 		if err != nil {
-			needRollback = true
-			logger.Errorf("Update a data view status and delete time error: %s", err.Error())
-			span.SetStatus(codes.Error, "Update a data view status and delete time failed")
-			return rest.NewHTTPError(ctx, http.StatusInternalServerError,
-				derrors.DataModel_DataView_InternalError_UpdateDataViewFailed).WithErrorDetails(err.Error())
+			return rest.NewHTTPError(ctx, http.StatusInternalServerError, derrors.DataModel_DataView_InternalError_UpdateDataViewFailed).
+				WithErrorDetails(err.Error())
 		}
-
-		logger.Infof("Update data view %s status to new success", view.ViewName)
 	}
 
-	// 请求更新资源名称的接口，更新资源的名称
-	err = dvs.ps.UpdateResource(ctx, interfaces.PermissionResource{
-		ID:   view.ViewID,
-		Type: interfaces.RESOURCE_TYPE_DATA_VIEW,
-		Name: common.ProcessUngroupedName(ctx, view.GroupName, view.ViewName),
-	})
-	if err != nil {
-		span.SetStatus(codes.Error, "Update resource name failed")
+	// 5. 提交事务
+	if err := tx.Commit(); err != nil {
 		return err
 	}
+	needRollback = false
 
-	span.SetStatus(codes.Ok, "")
+	// 6. 异步/同步更新外部资源中心 (非事务相关)
+	for _, view := range filteredViews {
+		_ = dvs.ps.UpdateResource(ctx, interfaces.PermissionResource{
+			ID:   view.ViewID,
+			Type: interfaces.RESOURCE_TYPE_DATA_VIEW,
+			Name: common.ProcessUngroupedName(ctx, view.GroupName, view.ViewName),
+		})
+	}
+
+	span.SetStatus(codes.Ok, "Batch sync successful")
+	return nil
+}
+
+// prepareAndViewCheck 执行更新前的校验与元数据补充
+// 假设：view.GroupID 已被外部调用方（如同步逻辑）正确填充
+func (dvs *dataViewService) prepareAndViewCheck(ctx context.Context, tx *sql.Tx, view, oldView *interfaces.DataView, now int64) error {
+	// A. 原子视图分组限制：不支持跨分组移动
+	if oldView.Type == interfaces.ViewType_Atomic && view.GroupName != oldView.GroupName {
+		return rest.NewHTTPError(ctx, http.StatusBadRequest, rest.PublicError_BadRequest).
+			WithErrorDetails(fmt.Sprintf("Atomic view '%s' forbidden group change: from '%s' to '%s'",
+				view.ViewID, oldView.GroupName, view.GroupName))
+	}
+
+	// C. 元数据补充
+	view.Updater = oldView.Updater // 保持原有 Updater 或按具体同步账号设置
+	view.UpdateTime = now
+
+	// 校验 Builtin 一致性 (如果同步后的 GroupID 与原先不同)
+	if view.GroupID == "" {
+		view.GroupID = oldView.GroupID // 兜底使用旧的 GroupID
+	}
+	// 校验内置逻辑
+	if oldView.Builtin && view.GroupID != oldView.GroupID {
+		logger.Warnf("Builtin view '%s' group changing from %s to %s", view.ViewID, oldView.GroupID, view.GroupID)
+	}
+
+	// D. 重命名或恢复时的冲突校验
+	// 仅在 ViewName 变动、GroupID 变动或视图处于恢复（DeleteTime > 0）状态时检查
+	isRestoring := oldView.DeleteTime > 0
+	isRenaming := view.ViewName != oldView.ViewName || view.GroupID != oldView.GroupID
+
+	if isRenaming || isRestoring {
+		existID, exist, err := dvs.CheckDataViewExistByName(ctx, tx, view.ViewName, view.GroupName)
+		if err != nil {
+			return err
+		}
+		if exist && existID != view.ViewID {
+			return rest.NewHTTPError(ctx, http.StatusForbidden, derrors.DataModel_DataView_Existed_ViewName).
+				WithDescription(map[string]any{"ViewName": view.ViewName, "GroupName": view.GroupName})
+		}
+	}
+
 	return nil
 }
 
@@ -873,6 +855,24 @@ func (dvs *dataViewService) GetDataViews(ctx context.Context, viewIDs []string, 
 	return views, nil
 }
 
+// 内部批量获取视图详情
+func (dvs *dataViewService) GetDataViewsInternal(ctx context.Context, viewIDs []string) ([]*interfaces.DataView, error) {
+	ctx, span := ar_trace.Tracer.Start(ctx, "logic layer: Get data views internal")
+	defer span.End()
+
+	views, err := dvs.dva.GetDataViews(ctx, viewIDs)
+	if err != nil {
+		logger.Errorf("Get data views failed, %s", err.Error())
+
+		span.SetStatus(codes.Error, "Get data views failed")
+		return nil, rest.NewHTTPError(ctx, http.StatusInternalServerError,
+			derrors.DataModel_DataView_InternalError_GetDataViewsFailed).WithErrorDetails(err.Error())
+	}
+
+	span.SetStatus(codes.Ok, "")
+	return views, nil
+}
+
 // 按分组导出数据视图
 func (dvs *dataViewService) GetDataViewsByGroupID(ctx context.Context, groupID string) ([]*interfaces.DataView, error) {
 	ctx, span := ar_trace.Tracer.Start(ctx, "logic layer: Get data views by group id")
@@ -1031,11 +1031,11 @@ func (dvs *dataViewService) GetDataViewsByGroupID(ctx context.Context, groupID s
 }
 
 // 按数据源获取数据视图
-func (dvs *dataViewService) GetDataViewsBySourceID(ctx context.Context, sourceID string) ([]*interfaces.DataView, error) {
-	ctx, span := ar_trace.Tracer.Start(ctx, "logic layer: Get data views by data source")
+func (dvs *dataViewService) GetDataViewIDsBySourceID(ctx context.Context, sourceID string) ([]string, error) {
+	ctx, span := ar_trace.Tracer.Start(ctx, "logic layer: Get data view IDs by data source")
 	defer span.End()
 
-	views, err := dvs.dva.GetDataViewsBySourceID(ctx, sourceID)
+	viewIDs, err := dvs.dva.GetDataViewsBySourceID(ctx, sourceID)
 	if err != nil {
 		logger.Errorf("Get data views by data source error: %s", err.Error())
 		span.SetStatus(codes.Error, "Get data views by data source failed")
@@ -1044,7 +1044,7 @@ func (dvs *dataViewService) GetDataViewsBySourceID(ctx context.Context, sourceID
 	}
 
 	span.SetStatus(codes.Ok, "")
-	return views, nil
+	return viewIDs, nil
 }
 
 // 分页查询数据视图
@@ -1149,6 +1149,24 @@ func (dvs *dataViewService) ListDataViews(ctx context.Context, param *interfaces
 
 	span.SetStatus(codes.Ok, "")
 	return results[param.Offset:end], len(results), nil
+}
+
+// 根据数据源获取数据视图ID
+func (dvs *dataViewService) ListDataViewsByDataSource(ctx context.Context, dataSourceID string) ([]*interfaces.ViewDeleteTime, error) {
+	ctx, span := ar_trace.Tracer.Start(ctx, "logic layer: List data views")
+	defer span.End()
+
+	views, err := dvs.dva.ListDataViewsByDataSource(ctx, dataSourceID)
+	if err != nil {
+		logger.Errorf("ListDataViewsByDataSource error: %s", err.Error())
+
+		span.SetStatus(codes.Error, "List data views failed")
+		return nil, rest.NewHTTPError(ctx, http.StatusInternalServerError,
+			derrors.DataModel_DataView_InternalError_ListDataViewsFailed).WithErrorDetails(err.Error())
+	}
+
+	span.SetStatus(codes.Ok, "")
+	return views, nil
 }
 
 // 根据名称检查数据视图是否存在，暴露 exist 参数，方便内部模块调用时根据exist决定后续行为
@@ -1956,5 +1974,84 @@ func (dvs *dataViewService) MarkDataViewsDeleted(ctx context.Context, tx *sql.Tx
 	}
 
 	span.SetStatus(codes.Ok, "mark data view deleted success")
+	return nil
+}
+
+// 批量创建数据视图（同步 monitor 专用，简化版）
+func (dvs *dataViewService) CreateDataViewsInternal(ctx context.Context, views []*interfaces.DataView) error {
+	ctx, span := ar_trace.Tracer.Start(ctx, "logic layer: Create data views internal (batch sync)")
+	defer span.End()
+
+	if len(views) == 0 {
+		return nil
+	}
+
+	span.SetAttributes(attr.Key("view_count").Int(len(views)))
+
+	now := time.Now().UnixMilli()
+	accountInfo := interfaces.AccountInfo{}
+	if ctx.Value(interfaces.ACCOUNT_INFO_KEY) != nil {
+		accountInfo = ctx.Value(interfaces.ACCOUNT_INFO_KEY).(interfaces.AccountInfo)
+	}
+
+	createdViews := make([]*interfaces.DataView, 0, len(views))
+	createSrcs := make([]interfaces.PermissionResource, 0, len(views))
+
+	for _, view := range views {
+		// 同步 monitor 创建的都是原子视图
+		view.Creator = accountInfo
+		view.Updater = accountInfo
+		view.CreateTime = now
+		view.UpdateTime = now
+
+		createdViews = append(createdViews, view)
+		createSrcs = append(createSrcs, interfaces.PermissionResource{
+			ID:   view.ViewID,
+			Type: interfaces.RESOURCE_TYPE_DATA_VIEW,
+			Name: common.ProcessUngroupedName(ctx, view.GroupName, view.ViewName),
+		})
+	}
+
+	// 开始事务进行批量写入
+	tx, err := dvs.db.Begin()
+	if err != nil {
+		return err
+	}
+
+	needRollback := true
+	defer func() {
+		if needRollback {
+			if rbErr := tx.Rollback(); rbErr != nil {
+				logger.Errorf("failed to rollback transaction: %v", rbErr)
+			}
+		} else {
+			if cmErr := tx.Commit(); cmErr != nil {
+				logger.Errorf("failed to commit transaction: %v", cmErr)
+			}
+		}
+	}()
+
+	// 分批插入数据库 [DB Batch]
+	batchSize := 2000
+	for i := 0; i < len(createdViews); i += batchSize {
+		end := i + batchSize
+		if end > len(createdViews) {
+			end = len(createdViews)
+		}
+		viewBatch := createdViews[i:end]
+		if err = dvs.dva.CreateDataViews(ctx, tx, viewBatch); err != nil {
+			logger.Errorf("CreateDataViewsInternal DB error: %s", err.Error())
+			return err
+		}
+	}
+
+	// 注册资源中心权限策略 [Policy Batch]
+	if err = dvs.ps.CreateResources(ctx, createSrcs, interfaces.COMMON_OPERATIONS); err != nil {
+		logger.Errorf("CreateDataViewsInternal Policy error: %s", err.Error())
+		return err
+	}
+
+	needRollback = false
+	span.SetStatus(codes.Ok, "Internal batch create successful")
 	return nil
 }

--- a/vega/mdl-data-model/server/worker/data_view_monitor.go
+++ b/vega/mdl-data-model/server/worker/data_view_monitor.go
@@ -11,7 +11,9 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"runtime"
 	"runtime/debug"
+	"sort"
 	"sync"
 	"time"
 
@@ -34,34 +36,30 @@ var (
 )
 
 type dataViewMonitorService struct {
-	appSetting   *common.AppSetting
-	dvs          interfaces.DataViewService
-	dvgs         interfaces.DataViewGroupService
-	ps           interfaces.PermissionService
-	dsa          interfaces.DataSourceAccess
-	vma          interfaces.VegaMetadataAccess
-	lastSyncTime string
-	mu           sync.RWMutex
-	results      []interfaces.SyncResult
-	batchResults []interfaces.BatchResult
-	initialized  bool
-	batchSize    int
+	appSetting          *common.AppSetting
+	dvs                 interfaces.DataViewService
+	dvgs                interfaces.DataViewGroupService
+	ps                  interfaces.PermissionService
+	dsa                 interfaces.DataSourceAccess
+	vma                 interfaces.VegaMetadataAccess
+	dataSourceSyncTimes map[string]string // 每个数据源的同步时间，key为数据源ID
+	mu                  sync.RWMutex
+	initialized         bool
+	batchSize           int
 }
 
 func NewDataViewMonitorService(appSetting *common.AppSetting) interfaces.DataViewMonitorService {
 	dvmServiceOnce.Do(func() {
 		dvmService = &dataViewMonitorService{
-			appSetting:   appSetting,
-			dvs:          data_view.NewDataViewService(appSetting),
-			dvgs:         data_view.NewDataViewGroupService(appSetting),
-			ps:           permission.NewPermissionService(appSetting),
-			dsa:          logics.DSA,
-			vma:          logics.VMA,
-			results:      make([]interfaces.SyncResult, 0),
-			batchResults: make([]interfaces.BatchResult, 0),
-			initialized:  true,
-			batchSize:    getDefaultBatchSize(),
-			lastSyncTime: "",
+			appSetting:          appSetting,
+			dvs:                 data_view.NewDataViewService(appSetting),
+			dvgs:                data_view.NewDataViewGroupService(appSetting),
+			ps:                  permission.NewPermissionService(appSetting),
+			dsa:                 logics.DSA,
+			vma:                 logics.VMA,
+			initialized:         true,
+			batchSize:           appSetting.ServerSetting.WatchMetadataBatchSize,
+			dataSourceSyncTimes: make(map[string]string),
 		}
 
 		if appSetting.ServerSetting.WatchMetadataEnabled {
@@ -113,44 +111,23 @@ func (dvmService *dataViewMonitorService) syncViews(ctx context.Context) error {
 	}
 
 	logger.Infof("Starting batch view synchronization...")
-	lastSync := dvmService.GetLastSyncTime()
 
-	// 决定同步类型
-	if lastSync == "" {
-		logger.Infof("Performing full sync - all metadata")
-		// 全量同步
-		err := dvmService.Sync(ctx, interfaces.SyncType_Full, "")
-		if err != nil {
-			logger.Errorf("Error performing full sync: %v", err)
-			return err
-		}
-		logger.Infof("Full sync completed successfully")
-
-	} else {
-		logger.Infof("Performing incremental sync since: %v", lastSync)
-		// 增量同步
-		err := dvmService.Sync(ctx, interfaces.SyncType_Incremental, lastSync)
-		if err != nil {
-			logger.Errorf("Error performing incremental sync: %v", err)
-			return err
-		}
-		logger.Infof("Incremental sync completed successfully")
+	err := dvmService.Sync(ctx)
+	if err != nil {
+		logger.Errorf("Error performing sync: %v", err)
+		return err
 	}
+	logger.Infof("Sync completed")
 
 	return nil
 }
 
-// 同步数据，记录每次同步开始的时间为 lastSyncTime
-func (dvmService *dataViewMonitorService) Sync(ctx context.Context, syncType string, lastSyncTime string) error {
+// Sync 同步所有数据源，每个数据源独立管理同步状态
+func (dvmService *dataViewMonitorService) Sync(ctx context.Context) error {
 	// 记录同步的开始时间
 	startTime := time.Now()
 
-	// 验证同步类型
-	if syncType != interfaces.SyncType_Full && syncType != interfaces.SyncType_Incremental {
-		return fmt.Errorf("invalid sync type: %s", syncType)
-	}
-
-	logger.Infof("Starting %s sync, lastSyncTime: %s", syncType, lastSyncTime)
+	logger.Infof("Starting sync process")
 
 	// 按照数据源同步，先获取数据源列表，再循环数据源获取元数据列表
 	dataSourceList, err := dvmService.dsa.ListDataSources(ctx)
@@ -181,32 +158,91 @@ func (dvmService *dataViewMonitorService) Sync(ctx context.Context, syncType str
 		return fmt.Errorf("failed to compare data sources and groups: %w", err)
 	}
 
-	// 循环数据源获取元数据列表
-	// 记录一个flag，是否全部更新成功
-	allSuccess := true
-	successCount := 0
-	totalCount := len(dataSourceList.Entries) - 1 // 去掉index_base数据源
+	// 准备数据源同步信息，用于排序
+	type dataSourceSyncInfo struct {
+		dataSource   *interfaces.DataSource
+		lastSyncTime string
+		syncType     string
+	}
 
+	// 收集需要同步的数据源及其同步状态
+	var syncInfos []dataSourceSyncInfo
+	totalCount := 0
 	for _, dataSource := range dataSourceList.Entries {
 		// 跳过index_base数据源
 		if dataSource.Type == interfaces.DataSourceType_IndexBase {
 			logger.Debugf("Skipping index_base data source: %s", dataSource.Name)
 			continue
 		}
+		totalCount++
+
+		lastSyncTime := dvmService.GetLastSyncTimeByDataSource(dataSource.ID)
+		syncType := interfaces.SyncType_Incremental
+		if lastSyncTime == "" {
+			syncType = interfaces.SyncType_Full
+		}
+
+		syncInfos = append(syncInfos, dataSourceSyncInfo{
+			dataSource:   dataSource,
+			lastSyncTime: lastSyncTime,
+			syncType:     syncType,
+		})
+	}
+
+	// 排序：全量同步（失败/首次）优先，增量同步在后
+	sort.Slice(syncInfos, func(i, j int) bool {
+		// 全量同步排在前面
+		if syncInfos[i].syncType != syncInfos[j].syncType {
+			return syncInfos[i].syncType == interfaces.SyncType_Full
+		}
+		// 相同类型按名称排序（保持稳定顺序）
+		return syncInfos[i].dataSource.Name < syncInfos[j].dataSource.Name
+	})
+
+	// 记录统计信息
+	fullSyncCount := 0
+	incrementalSyncCount := 0
+	for _, info := range syncInfos {
+		if info.syncType == interfaces.SyncType_Full {
+			fullSyncCount++
+		} else {
+			incrementalSyncCount++
+		}
+	}
+	logger.Infof("Sync priority: %d data sources need full sync (failed/first-time), %d need incremental sync",
+		fullSyncCount, incrementalSyncCount)
+
+	// 按排序后的顺序同步数据源
+	successCount := 0
+	for _, info := range syncInfos {
+		dataSource := info.dataSource
+
+		if info.syncType == interfaces.SyncType_Full {
+			logger.Infof("Data source '%s' has no last sync time (failed/first-time), will perform full sync", dataSource.Name)
+		} else {
+			logger.Infof("Data source '%s' will perform incremental sync since: %s", dataSource.Name, info.lastSyncTime)
+		}
 
 		// 记录每个数据源的同步时间
 		dataSourceStartTime := time.Now()
-		err := dvmService.syncDataSource(ctx, dataSource, syncType, lastSyncTime)
+
+		err := dvmService.syncDataSource(ctx, dataSource, info.syncType, info.lastSyncTime)
 		// 记录当前数据源的同步时间
 		dataSourceEndTime := time.Now()
 		dataSourceDuration := dataSourceEndTime.Sub(dataSourceStartTime).Milliseconds()
-		logger.Infof("Data source '%s' synced in %v ms", dataSource.Name, dataSourceDuration)
+
 		if err != nil {
 			logger.Errorf("Error syncing data source '%s': %v", dataSource.Name, err)
-			allSuccess = false
 		} else {
+			// 只有同步成功才更新该数据源的同步时间
+			dvmService.setLastSyncTimeByDataSource(dataSource.ID, dataSourceStartTime.Format(time.RFC3339Nano))
+			logger.Infof("Data source '%s' synced successfully in %v ms, sync time updated", dataSource.Name, dataSourceDuration)
 			successCount++
 		}
+
+		// 主动释放每个数据源处理完后的内存，避免峰值 OOM
+		runtime.GC()
+		debug.FreeOSMemory()
 	}
 
 	endTime := time.Now()
@@ -215,11 +251,7 @@ func (dvmService *dataViewMonitorService) Sync(ctx context.Context, syncType str
 	// 记录同步统计信息
 	logger.Infof("Sync completed in %v ms, success: %d/%d data sources", duration, successCount, totalCount)
 
-	// 如果全部数据源同步成功，更新 lastSyncTime
-	if allSuccess {
-		dvmService.setLastSyncTime(startTime.Format(time.RFC3339Nano))
-		logger.Infof("Sync state updated in memory: %v", dvmService.GetLastSyncTime())
-	} else {
+	if successCount < totalCount {
 		logger.Warnf("Sync completed with errors, %d/%d data sources failed", totalCount-successCount, totalCount)
 	}
 
@@ -229,19 +261,17 @@ func (dvmService *dataViewMonitorService) Sync(ctx context.Context, syncType str
 // 同步单个数据源
 func (dvmService *dataViewMonitorService) syncDataSource(ctx context.Context, dataSource *interfaces.DataSource, syncType string, lastSyncTime string) error {
 	// 先操作标记源表删除，源表删除需要全量获取表，不能拿增量查询的库表和全量视图对比
-	// 获取这个数据源（分组）下的所有视图
-	dataViews, err := dvmService.dvs.GetDataViewsBySourceID(ctx, dataSource.ID)
+	// 获取这个数据源（分组）下的所有视图 ID (使用 ListDataViews 获取 SimpleDataView 以节省内存)
+
+	dataViews, err := dvmService.dvs.ListDataViewsByDataSource(ctx, dataSource.ID)
 	if err != nil {
-		return fmt.Errorf("failed to get data views: %w", err)
+		return fmt.Errorf("failed to list data views: %w", err)
 	}
 
-	// 这个数据源下的所有视图，用技术名称作为key
-	dataViewsMap := make(map[string]*interfaces.DataView)
-	// 维护业务名称和业务id的map，避免新生成的业务名称会在分组内重复
-	// dataViewBusinessNameMap := make(map[string]string)
+	// 这个数据源下的所有视图
+	dataViewsMap := make(map[string]int64)
 	for _, dView := range dataViews {
-		dataViewsMap[dView.TechnicalName] = dView
-		// dataViewBusinessNameMap[dView.ViewName] = dView.ViewID
+		dataViewsMap[dView.ViewID] = dView.DeleteTime
 	}
 
 	// 标记源表被删除的视图
@@ -279,7 +309,8 @@ func (dvmService *dataViewMonitorService) syncDataSource(ctx context.Context, da
 }
 
 // 标记源表被删除的视图
-func (dvmService *dataViewMonitorService) markDeletedTablesAsSourceDeleted(ctx context.Context, dataSource *interfaces.DataSource, dataViewsMap map[string]*interfaces.DataView) error {
+func (dvmService *dataViewMonitorService) markDeletedTablesAsSourceDeleted(ctx context.Context,
+	dataSource *interfaces.DataSource, dataViewsMap map[string]int64) error {
 	allMetadata, err := dvmService.getMetadataBySourceID(ctx, dataSource.ID, "")
 	if err != nil {
 		return fmt.Errorf("failed to get metadata when mark deleted tables: %w", err)
@@ -288,17 +319,18 @@ func (dvmService *dataViewMonitorService) markDeletedTablesAsSourceDeleted(ctx c
 	logger.Infof("data source '%s' metadata records count: %d, data views count: %d",
 		dataSource.Name, len(allMetadata), len(dataViewsMap))
 
-	// table.Name 是视图的技术名称
 	tablesMap := make(map[string]interfaces.SimpleMetadataTable)
 	for _, table := range allMetadata {
-		tablesMap[table.Name] = table
+		tablesMap[table.ID] = table
 	}
 
-	// 源表被删除了，标记为源表删除
+	// 源表被删除了，标记为源表删除, 如果已经被标记过了，不再标记
 	deleteViewIDs := make([]string, 0)
-	for techName, vv := range dataViewsMap {
-		if _, ok := tablesMap[techName]; !ok {
-			deleteViewIDs = append(deleteViewIDs, vv.ViewID)
+	for dViewID, deleteTime := range dataViewsMap {
+		if _, ok := tablesMap[dViewID]; !ok {
+			if deleteTime == 0 {
+				deleteViewIDs = append(deleteViewIDs, dViewID)
+			}
 		}
 	}
 
@@ -320,29 +352,23 @@ func (dvmService *dataViewMonitorService) markDeletedTablesAsSourceDeleted(ctx c
 // 为没有元数据的数据源标记视图为源表删除
 func (dvmService *dataViewMonitorService) markViewsAsSourceDeletedForEmptyMetadata(ctx context.Context, dataSource *interfaces.DataSource) error {
 	// 获取这个数据源下的所有视图
-	dataViews, err := dvmService.dvs.GetDataViewsBySourceID(ctx, dataSource.ID)
+	dataViewIDs, err := dvmService.dvs.GetDataViewIDsBySourceID(ctx, dataSource.ID)
 	if err != nil {
 		return fmt.Errorf("failed to get data views: %w", err)
 	}
 
-	if len(dataViews) == 0 {
+	if len(dataViewIDs) == 0 {
 		logger.Infof("No views found for data source '%s' with empty metadata", dataSource.Name)
 		return nil
 	}
 
-	// 收集需要标记为源表删除的视图ID
-	deleteViewIDs := make([]string, 0, len(dataViews))
-	for _, view := range dataViews {
-		deleteViewIDs = append(deleteViewIDs, view.ViewID)
-	}
-
 	// 标记视图为源表删除
-	err = dvmService.MarkViewAsSourceDeleted(ctx, deleteViewIDs)
+	err = dvmService.MarkViewAsSourceDeleted(ctx, dataViewIDs)
 	if err != nil {
 		return fmt.Errorf("failed to mark views as source deleted: %w", err)
 	}
 
-	logger.Infof("Marked %d views as source deleted for data source '%s' in full sync", len(deleteViewIDs), dataSource.Name)
+	logger.Infof("Marked %d views as source deleted for data source '%s' in full sync", len(dataViewIDs), dataSource.Name)
 	return nil
 }
 
@@ -420,12 +446,11 @@ func (dvmService *dataViewMonitorService) compareDataSourceAndBuiltinGroups(ctx 
 
 // 对于每个数据源的元数据，进行批量处理
 func (dvmService *dataViewMonitorService) processMetadataByDataSource(ctx context.Context, metadataList []interfaces.SimpleMetadataTable,
-	dataSource *interfaces.DataSource, dataViewsMap map[string]*interfaces.DataView) error {
+	dataSource *interfaces.DataSource, dataViewsMap map[string]int64) error {
 	// 将元数据分批次
 	batches := chunkMetadata(metadataList, dvmService.batchSize)
 	logger.Infof("Batch size: %d, Split into %d batches", dvmService.batchSize, len(batches))
 
-	var allSyncResults []interfaces.SyncResult
 	var processedCount, totalCount int
 	// var newSyncTime string
 
@@ -438,18 +463,8 @@ func (dvmService *dataViewMonitorService) processMetadataByDataSource(ctx contex
 			return err
 		}
 
-		allSyncResults = append(allSyncResults, batchResult.Results...)
 		processedCount += batchResult.SuccessCount
 		totalCount += batchResult.TotalCount
-
-		// 记录批次结果
-		dvmService.mu.Lock()
-		dvmService.batchResults = append(dvmService.batchResults, batchResult)
-		// 保持批次结果列表大小可控
-		if len(dvmService.batchResults) > 100 {
-			dvmService.batchResults = dvmService.batchResults[len(dvmService.batchResults)-100:]
-		}
-		dvmService.mu.Unlock()
 
 		// 对于增量同步，更新最大的更新时间
 		// if syncType == interfaces.SyncType_Incremental {
@@ -480,15 +495,6 @@ func (dvmService *dataViewMonitorService) processMetadataByDataSource(ctx contex
 			batchResult.NeedUpdatedCount)
 	}
 
-	// 更新内存中的同步状态
-	dvmService.mu.Lock()
-	dvmService.results = append(dvmService.results, allSyncResults...)
-	// 保持结果列表大小可控
-	if len(dvmService.results) > 1000 {
-		dvmService.results = dvmService.results[len(dvmService.results)-1000:]
-	}
-	dvmService.mu.Unlock()
-
 	logger.Infof("Batch synchronization completed. Total: %d batches, %d/%d successful",
 		len(batches), processedCount, totalCount)
 
@@ -497,7 +503,7 @@ func (dvmService *dataViewMonitorService) processMetadataByDataSource(ctx contex
 
 // processBatch 处理单个批次
 func (dvmService *dataViewMonitorService) processBatch(ctx context.Context, batchID int, metadataList []interfaces.SimpleMetadataTable,
-	dataSource *interfaces.DataSource, dataViewsMap map[string]*interfaces.DataView) (interfaces.BatchResult, error) {
+	dataSource *interfaces.DataSource, dataViewsMap map[string]int64) (interfaces.BatchResult, error) {
 	batchStart := time.Now()
 
 	logger.Infof("Processing batch %d with %d metadata records for data source '%s'",
@@ -522,7 +528,7 @@ func (dvmService *dataViewMonitorService) processBatch(ctx context.Context, batc
 	for _, table := range metaTablesInfo {
 		if table.Table != nil {
 			validMetaTableCount++
-			if _, ok := dataViewsMap[table.Table.Name]; !ok {
+			if _, ok := dataViewsMap[table.Table.ID]; !ok {
 				needCreatedTables = append(needCreatedTables, table)
 			} else {
 				needUpdatedTables = append(needUpdatedTables, table)
@@ -606,7 +612,7 @@ func (dvmService *dataViewMonitorService) createViews(ctx context.Context, table
 	}
 
 	logger.Infof("[SyncAtomicView] create view count: %d", len(createViews))
-	if _, err = dvmService.dvs.CreateDataViews(ctx, createViews, interfaces.ImportMode_Normal, false); err != nil {
+	if err = dvmService.dvs.CreateDataViewsInternal(ctx, createViews); err != nil {
 		errDetails := fmt.Sprintf("[SyncAtomicView] create view database error, %v", err)
 		span.SetStatus(codes.Error, "CreateView create view database error")
 		o11y.Error(ctx, errDetails)
@@ -621,22 +627,48 @@ func (dvmService *dataViewMonitorService) createViews(ctx context.Context, table
 
 // 批量更新视图
 func (dvmService *dataViewMonitorService) updateViews(ctx context.Context, tables []interfaces.MetadataTable,
-	dataViewsMap map[string]*interfaces.DataView) error {
+	dataViewsMap map[string]int64) error {
 	ctx, span := ar_trace.Tracer.Start(ctx, "Atomic View Sync: Update data views")
 	defer span.End()
 
-	updateViews, err := dvmService.initUpdatedViews(tables, dataViewsMap)
+	// 1. 收集当前批次需要更新的视图 ID
+	viewIDs := make([]string, 0, len(tables))
+	for _, table := range tables {
+		if _, ok := dataViewsMap[table.Table.ID]; ok {
+			viewIDs = append(viewIDs, table.Table.ID)
+		}
+	}
+
+	if len(viewIDs) == 0 {
+		return nil
+	}
+
+	// 2. 批量获取这些视图的完整详情 (包含 Fields 等大数据结构，处理完后释放)
+	fullViews, err := dvmService.dvs.GetDataViewsInternal(ctx, viewIDs)
+	if err != nil {
+		logger.Errorf("GetDataViewsInternal failed, err: %v", err)
+		return err
+	}
+
+	// 3. 建立视图 ID 到完整视图的映射
+	fullViewsMap := make(map[string]*interfaces.DataView)
+	for _, fv := range fullViews {
+		fullViewsMap[fv.ViewID] = fv
+	}
+
+	// 4. 初始化更新内容 (这里的 fullViewsMap 会在函数结束后进入垃圾回收待处理列表)
+	updateViews, err := dvmService.initUpdatedViews(tables, fullViewsMap)
 	if err != nil {
 		logger.Errorf("init views failed, err: %v", err)
 		return err
 	}
 
 	logger.Infof("[SyncAtomicView] update view count: %d", len(updateViews))
-	for _, view := range updateViews {
-		if err := dvmService.dvs.UpdateDataViewInternal(ctx, view); err != nil {
-			span.SetStatus(codes.Error, "Update data view failed")
-			o11y.Error(ctx, fmt.Sprintf("Update data view error, %v", err))
-			return fmt.Errorf("[SyncAtomicView] update view error, %v", err)
+	if len(updateViews) > 0 {
+		if err := dvmService.dvs.UpdateDataViewsInternal(ctx, updateViews); err != nil {
+			span.SetStatus(codes.Error, "Batch update data views failed")
+			o11y.Error(ctx, fmt.Sprintf("Batch update data views error, %v", err))
+			return fmt.Errorf("[SyncAtomicView] batch update view error, %v", err)
 		}
 	}
 
@@ -662,6 +694,8 @@ func (dvmService *dataViewMonitorService) initCreatedViews(tables []interfaces.M
 			var features []interfaces.FieldFeature
 			if isOpenSearchOrIndexBaseDataSource(table.DataSource.Type) {
 				features = generateNativeFieldFeatures(fieldType, mField)
+				// 启用每个类型的第一个特征
+				enableFirstFeatureOfEachType(features)
 			}
 
 			fields[i] = &interfaces.ViewField{
@@ -741,6 +775,10 @@ func (dvmService *dataViewMonitorService) initCreatedViews(tables []interfaces.M
 		if schemaName == "" {
 			schemaName = table.DataSource.Database
 		}
+		// database也没有使用默认值 default
+		if schemaName == "" {
+			schemaName = interfaces.DefaultSchema
+		}
 
 		// 补齐 sqlstr 和 metatable name
 		metaTableName := fmt.Sprintf("%s.%s.%s", catalogName, common.QuotationMark(schemaName), common.QuotationMark(table.Table.Name))
@@ -755,112 +793,24 @@ func (dvmService *dataViewMonitorService) initCreatedViews(tables []interfaces.M
 }
 
 // initUpdatedViews 初始化需要更新的视图, 实现“增量更新”且“不覆盖用户自定义配置”
+// 只有检测到实际变化时才返回需要更新的视图
 func (dvmService *dataViewMonitorService) initUpdatedViews(tables []interfaces.MetadataTable,
 	dataViewsMap map[string]*interfaces.DataView) ([]*interfaces.DataView, error) {
 	atomicViews := make([]*interfaces.DataView, 0, len(tables))
+	skippedCount := 0
+
 	for _, table := range tables {
-		existingView, ok := dataViewsMap[table.Table.Name]
+		existingView, ok := dataViewsMap[table.Table.ID]
 		if !ok {
 			continue
 		}
 
-		// 已有的字段列表
-		existingFieldsMap := make(map[string]*interfaces.ViewField)
-		for _, vfield := range existingView.Fields {
-			existingFieldsMap[vfield.OriginalName] = vfield
-		}
-		logger.Debugf("update view metadata table %s fields count is %d, view %s fields count is %d",
-			table.Table.Name, len(table.FieldList), existingView.ViewName, len(existingView.Fields))
-
-		var selectFields string
-		// fields := make([]*interfaces.ViewField, len(table.FieldList))
-		primaryKeys := make([]string, 0)
-		final_view_fields := make([]*interfaces.ViewField, 0, len(table.FieldList))
-		for _, mField := range table.FieldList {
-			if oldField, ok := existingFieldsMap[mField.FieldName]; !ok {
-				//field new
-				logger.Debugf("update view, table name: %s, field name: %s, field not exist in view",
-					table.Table.Name, mField.FieldName)
-				fieldType := mField.AdvancedParams.GetValue(interfaces.FieldAdvancedParams_VirtualDataType).(string)
-				isNullable := mField.AdvancedParams.GetValue(interfaces.FieldAdvancedParams_IsNullable).(string)
-				if fieldType == "" {
-					logger.Warnf("table '%s' field '%s' type is empty", table.Table.Name, mField.FieldName)
-				}
-
-				var osFeatures []interfaces.FieldFeature
-				if isOpenSearchOrIndexBaseDataSource(table.DataSource.Type) {
-					osFeatures = generateNativeFieldFeatures(fieldType, mField)
-				}
-
-				newField := &interfaces.ViewField{
-					Name:         mField.FieldName,
-					DisplayName:  mField.FieldName,
-					OriginalName: mField.FieldName,
-					Comment:      common.CutStringByCharCount(mField.FieldComment, interfaces.MaxLength_ViewFieldComment),
-					Status:       interfaces.FieldScanStatus_New,
-					IsPrimaryKey: sql.NullBool{Bool: mField.AdvancedParams.IsPrimaryKey(), Valid: true},
-					Type:         fieldType,
-					DataLength:   mField.FieldLength,
-					DataAccuracy: mField.FieldPrecision,
-					IsNullable:   isNullable,
-					Features:     osFeatures,
-				}
-
-				if fieldType == "" { //不支持的类型设置状态
-					newField.Status = interfaces.FieldScanStatus_NotSupport
-				} else {
-					selectFields = common.CE(selectFields == "", common.QuotationMark(mField.FieldName),
-						fmt.Sprintf("%s,%s", selectFields, common.QuotationMark(mField.FieldName))).(string)
-				}
-				// 新增字段加入最终字段列表
-				final_view_fields = append(final_view_fields, newField)
-
-				if mField.AdvancedParams.IsPrimaryKey() {
-					primaryKeys = append(primaryKeys, mField.FieldName)
-				}
-			} else {
-				// field update
-				logger.Debugf("update view, table name: %s, field name: %s, field already exists in view",
-					table.Table.Name, mField.FieldName)
-				fieldType := mField.AdvancedParams.GetValue(interfaces.FieldAdvancedParams_VirtualDataType).(string)
-				isNullable := mField.AdvancedParams.GetValue(interfaces.FieldAdvancedParams_IsNullable).(string)
-				if fieldType == "" {
-					logger.Warnf("table '%s' field '%s' type is empty", table.Table.Name, mField.FieldName)
-				}
-
-				var mergedFeatures []interfaces.FieldFeature
-				if isOpenSearchOrIndexBaseDataSource(table.DataSource.Type) {
-					osFeatures := generateNativeFieldFeatures(fieldType, mField)
-					mergedFeatures = MergeFeaturesOptimized(oldField.Features, osFeatures)
-				}
-
-				updateField := &interfaces.ViewField{
-					Name:         mField.FieldName,
-					DisplayName:  oldField.DisplayName,
-					OriginalName: mField.FieldName,
-					Comment:      oldField.Comment,
-					Status:       interfaces.FieldScanStatus_Modify,
-					IsPrimaryKey: sql.NullBool{Bool: mField.AdvancedParams.IsPrimaryKey(), Valid: true},
-					Type:         fieldType,
-					DataLength:   mField.FieldLength,
-					DataAccuracy: mField.FieldPrecision,
-					IsNullable:   isNullable,
-					Features:     mergedFeatures,
-				}
-
-				if fieldType == "" { //不支持的类型设置状态
-					updateField.Status = interfaces.FieldScanStatus_NotSupport
-				} else {
-					selectFields = common.CE(selectFields == "", common.QuotationMark(mField.FieldName),
-						fmt.Sprintf("%s,%s", selectFields, common.QuotationMark(mField.FieldName))).(string)
-				}
-				// 更新的字段加入最终字段列表
-				final_view_fields = append(final_view_fields, updateField)
-
-				if mField.AdvancedParams.IsPrimaryKey() {
-					primaryKeys = append(primaryKeys, mField.FieldName)
-				}
-			}
+		// 检测是否有实际变化
+		hasChanges, finalViewFields, primaryKeys := dvmService.detectChangesAndViewFields(table, existingView)
+		if !hasChanges {
+			skippedCount++
+			// logger.Debugf("No changes detected for view '%s', skipping update", existingView.ViewName)
+			continue
 		}
 
 		// 获取 excel 数据源的excelConfig
@@ -900,12 +850,10 @@ func (dvmService *dataViewMonitorService) initUpdatedViews(tables []interfaces.M
 				DataSourceType: table.DataSource.Type,
 				FileName:       excelFileName,
 				Status:         interfaces.ViewScanStatus_Modify,
-				// Comment:        common.CutStringByCharCount(table.Table.Description, interfaces.CommentCharCountLimit),
-				Comment: existingView.Comment,
+				Comment:        existingView.Comment,
 			},
-			ExcelConfig: excelConfig,
-			// Fields:         fields,
-			Fields:         final_view_fields,
+			ExcelConfig:    excelConfig,
+			Fields:         finalViewFields,
 			MetadataFormID: table.TableID,
 			PrimaryKeys:    primaryKeys,
 		}
@@ -916,6 +864,10 @@ func (dvmService *dataViewMonitorService) initUpdatedViews(tables []interfaces.M
 		if schemaName == "" {
 			schemaName = table.DataSource.Database
 		}
+		// database也没有使用默认值 default
+		if schemaName == "" {
+			schemaName = interfaces.DefaultSchema
+		}
 
 		// 补齐 sqlstr 和 metatable name
 		metaTableName := fmt.Sprintf("%s.%s.%s", catalogName, common.QuotationMark(schemaName), common.QuotationMark(table.Table.Name))
@@ -923,16 +875,266 @@ func (dvmService *dataViewMonitorService) initUpdatedViews(tables []interfaces.M
 		view.MetaTableName = metaTableName
 
 		atomicViews = append(atomicViews, view)
+	}
 
+	if skippedCount > 0 {
+		logger.Infof("Skipped %d views with no changes", skippedCount)
 	}
 
 	return atomicViews, nil
 }
 
+// detectChangesAndViewFields 检测视图是否有变化，并构建更新后的字段列表
+// 返回: hasChanges（是否有变化）, finalFields（最终字段列表）, primaryKeys（主键列表）
+func (dvmService *dataViewMonitorService) detectChangesAndViewFields(table interfaces.MetadataTable,
+	existingView *interfaces.DataView) (bool, []*interfaces.ViewField, []string) {
+
+	// 已有的字段列表
+	existingFieldsMap := make(map[string]*interfaces.ViewField)
+	for _, vfield := range existingView.Fields {
+		existingFieldsMap[vfield.OriginalName] = vfield
+	}
+
+	hasChanges := false
+	primaryKeys := make([]string, 0)
+	finalViewFields := make([]*interfaces.ViewField, 0, len(table.FieldList))
+
+	// 检测新增字段和字段属性变化
+	for _, mField := range table.FieldList {
+		oldField, exists := existingFieldsMap[mField.FieldName]
+
+		fieldType := mField.AdvancedParams.GetValue(interfaces.FieldAdvancedParams_VirtualDataType).(string)
+		isNullable := mField.AdvancedParams.GetValue(interfaces.FieldAdvancedParams_IsNullable).(string)
+
+		if !exists {
+			// 新增字段
+			hasChanges = true
+			logger.Debugf("New field detected: %s.%s", table.Table.Name, mField.FieldName)
+
+			if fieldType == "" {
+				logger.Warnf("table '%s' field '%s' type is empty", table.Table.Name, mField.FieldName)
+			}
+
+			var osFeatures []interfaces.FieldFeature
+			if isOpenSearchOrIndexBaseDataSource(table.DataSource.Type) {
+				osFeatures = generateNativeFieldFeatures(fieldType, mField)
+				// 启用每个类型的第一个特征
+				enableFirstFeatureOfEachType(osFeatures)
+			}
+
+			newField := &interfaces.ViewField{
+				Name:         mField.FieldName,
+				DisplayName:  mField.FieldName,
+				OriginalName: mField.FieldName,
+				Comment:      common.CutStringByCharCount(mField.FieldComment, interfaces.MaxLength_ViewFieldComment),
+				Status:       interfaces.FieldScanStatus_New,
+				IsPrimaryKey: sql.NullBool{Bool: mField.AdvancedParams.IsPrimaryKey(), Valid: true},
+				Type:         fieldType,
+				DataLength:   mField.FieldLength,
+				DataAccuracy: mField.FieldPrecision,
+				IsNullable:   isNullable,
+				Features:     osFeatures,
+			}
+
+			if fieldType == "" {
+				newField.Status = interfaces.FieldScanStatus_NotSupport
+			}
+
+			finalViewFields = append(finalViewFields, newField)
+
+			if mField.AdvancedParams.IsPrimaryKey() {
+				primaryKeys = append(primaryKeys, mField.FieldName)
+			}
+		} else {
+			// 已有字段，检测属性变化
+			fieldChanged := false
+
+			// 检测字段类型变化
+			if oldField.Type != fieldType {
+				fieldChanged = true
+				logger.Debugf("Field type changed: %s.%s, old: %s, new: %s", table.Table.Name, mField.FieldName, oldField.Type, fieldType)
+			}
+
+			// 检测字段长度变化
+			if oldField.DataLength != mField.FieldLength {
+				fieldChanged = true
+				logger.Debugf("Field length changed: %s.%s, old: %d, new: %d", table.Table.Name, mField.FieldName, oldField.DataLength, mField.FieldLength)
+			}
+
+			// 检测字段精度变化
+			if oldField.DataAccuracy != mField.FieldPrecision {
+				fieldChanged = true
+				logger.Debugf("Field accuracy changed: %s.%s, old: %d, new: %d", table.Table.Name, mField.FieldName, oldField.DataAccuracy, mField.FieldPrecision)
+			}
+
+			// 检测可空性变化
+			if oldField.IsNullable != isNullable {
+				fieldChanged = true
+				logger.Debugf("Field nullable changed: %s.%s, old: %s, new: %s", table.Table.Name, mField.FieldName, oldField.IsNullable, isNullable)
+			}
+
+			// 检测主键变化
+			oldIsPK := oldField.IsPrimaryKey.Valid && oldField.IsPrimaryKey.Bool
+			newIsPK := mField.AdvancedParams.IsPrimaryKey()
+			if oldIsPK != newIsPK {
+				fieldChanged = true
+				logger.Debugf("Field primary key changed: %s.%s, old: %v, new: %v", table.Table.Name, mField.FieldName, oldIsPK, newIsPK)
+			}
+
+			// 检测特征变化（仅对 OpenSearch/IndexBase 数据源）
+			var mergedFeatures []interfaces.FieldFeature
+			if isOpenSearchOrIndexBaseDataSource(table.DataSource.Type) {
+				osFeatures := generateNativeFieldFeatures(fieldType, mField)
+				mergedFeatures = MergeFeaturesOptimized(oldField.Features, osFeatures)
+
+				// 比较特征是否变化
+				if !featuresEqual(oldField.Features, mergedFeatures) {
+					fieldChanged = true
+					logger.Debugf("Field features changed: %s.%s", table.Table.Name, mField.FieldName)
+				}
+			} else {
+				mergedFeatures = oldField.Features
+			}
+
+			if fieldChanged {
+				hasChanges = true
+			}
+
+			updateField := &interfaces.ViewField{
+				Name:         mField.FieldName,
+				DisplayName:  oldField.DisplayName,
+				OriginalName: mField.FieldName,
+				Comment:      oldField.Comment,
+				Status:       interfaces.FieldScanStatus_Modify,
+				IsPrimaryKey: sql.NullBool{Bool: mField.AdvancedParams.IsPrimaryKey(), Valid: true},
+				Type:         fieldType,
+				DataLength:   mField.FieldLength,
+				DataAccuracy: mField.FieldPrecision,
+				IsNullable:   isNullable,
+				Features:     mergedFeatures,
+			}
+
+			if fieldType == "" {
+				updateField.Status = interfaces.FieldScanStatus_NotSupport
+			}
+
+			finalViewFields = append(finalViewFields, updateField)
+
+			if mField.AdvancedParams.IsPrimaryKey() {
+				primaryKeys = append(primaryKeys, mField.FieldName)
+			}
+		}
+	}
+
+	// 检测删除的字段
+	newFieldsMap := make(map[string]bool)
+	for _, mField := range table.FieldList {
+		newFieldsMap[mField.FieldName] = true
+	}
+	for _, oldField := range existingView.Fields {
+		if !newFieldsMap[oldField.OriginalName] {
+			hasChanges = true
+			logger.Debugf("Deleted field detected: %s.%s", table.Table.Name, oldField.OriginalName)
+		}
+	}
+
+	return hasChanges, finalViewFields, primaryKeys
+}
+
+// featuresEqual 比较两个特征列表是否相等
+func featuresEqual(a, b []interfaces.FieldFeature) bool {
+	if len(a) != len(b) {
+		logger.Debugf("Feature length mismatch: %d != %d", len(a), len(b))
+		return false
+	}
+
+	// 建立特征映射，使用 FeatureType+RefField 作为key
+	aMap := make(map[string]interfaces.FieldFeature)
+	for _, f := range a {
+		key := fmt.Sprintf("%s|%s", f.FeatureType, f.RefField)
+		aMap[key] = f
+	}
+
+	for _, f := range b {
+		key := fmt.Sprintf("%s|%s", f.FeatureType, f.RefField)
+		aFeature, exists := aMap[key]
+		if !exists {
+			logger.Debugf("Feature not found: %s in a", key)
+			return false
+		}
+
+		// 比较配置是否相同
+		// 注意：JSON 反序列化后数字类型为 float64，而代码中构造的默认值为 int，
+		// 因此不能直接用 reflect.DeepEqual，需要做数值归一化比较。
+		if !configEqual(aFeature.Config, f.Config) {
+			logger.Debugf("Feature config mismatch: %s, aFeature.Config: %+v, f.Config: %+v", key, aFeature.Config, f.Config)
+			return false
+		}
+		if aFeature.IsDefault != f.IsDefault {
+			logger.Debugf("Feature default mismatch: %s, aFeature.IsDefault: %v, f.IsDefault: %v", key, aFeature.IsDefault, f.IsDefault)
+			return false
+		}
+	}
+
+	return true
+}
+
+// configEqual 比较两个 map[string]any 是否相等，对数值类型做归一化处理。
+// JSON 反序列化后数字统一为 float64，而代码中构造的默认值可能是 int，
+// 通过统一转为 float64 字符串形式比较，避免类型不同导致的误判。
+func configEqual(a, b map[string]any) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, av := range a {
+		bv, ok := b[k]
+		if !ok {
+			return false
+		}
+		if !anyEqual(av, bv) {
+			return false
+		}
+	}
+	return true
+}
+
+// anyEqual 比较两个 any 值是否相等，数值类型统一转为 float64 后比较。
+func anyEqual(a, b any) bool {
+	af, aIsNum := toFloat64(a)
+	bf, bIsNum := toFloat64(b)
+	if aIsNum && bIsNum {
+		return af == bf
+	}
+	return reflect.DeepEqual(a, b)
+}
+
+// toFloat64 尝试将 any 转换为 float64，仅支持常见数值类型。
+func toFloat64(v any) (float64, bool) {
+	switch n := v.(type) {
+	case float64:
+		return n, true
+	case float32:
+		return float64(n), true
+	case int:
+		return float64(n), true
+	case int32:
+		return float64(n), true
+	case int64:
+		return float64(n), true
+	case uint:
+		return float64(n), true
+	case uint32:
+		return float64(n), true
+	case uint64:
+		return float64(n), true
+	}
+	return 0, false
+}
+
 // chunkMetadata 将元数据列表分批次
 func chunkMetadata(metadataList []interfaces.SimpleMetadataTable, batchSize int) [][]interfaces.SimpleMetadataTable {
 	if batchSize <= 0 {
-		batchSize = 1000 // 默认批次大小
+		batchSize = 500 // 默认批次大小
 	}
 
 	var chunks [][]interfaces.SimpleMetadataTable
@@ -946,16 +1148,11 @@ func chunkMetadata(metadataList []interfaces.SimpleMetadataTable, batchSize int)
 	return chunks
 }
 
-// getDefaultBatchSize 获取默认批次大小
-func getDefaultBatchSize() int {
-	return 1000
-}
-
 func (dvmService *dataViewMonitorService) MarkViewAsSourceDeleted(ctx context.Context, viewsIDs []string) error {
 	ctx, span := ar_trace.Tracer.Start(ctx, "logic layer: Mark view as source deleted")
 	defer span.End()
 
-	logger.Infof("MarkViewAsSourceDeleted views %+v", viewsIDs)
+	logger.Infof("will marking view as source deleted, views count: %d", len(viewsIDs))
 	if len(viewsIDs) == 0 {
 		span.SetStatus(codes.Ok, "viewsIDs is empty")
 		return nil
@@ -972,18 +1169,30 @@ func (dvmService *dataViewMonitorService) MarkViewAsSourceDeleted(ctx context.Co
 	return nil
 }
 
-// GetLastSyncTime 获取最后同步时间
-func (dvmService *dataViewMonitorService) GetLastSyncTime() string {
+// GetLastSyncTimeByDataSource 获取指定数据源的最后同步时间
+func (dvmService *dataViewMonitorService) GetLastSyncTimeByDataSource(dataSourceID string) string {
 	dvmService.mu.RLock()
 	defer dvmService.mu.RUnlock()
-	return dvmService.lastSyncTime
+	return dvmService.dataSourceSyncTimes[dataSourceID]
 }
 
-// setLastSyncTime 设置最后同步时间
-func (dvmService *dataViewMonitorService) setLastSyncTime(lastSyncTime string) {
+// setLastSyncTimeByDataSource 设置指定数据源的最后同步时间
+func (dvmService *dataViewMonitorService) setLastSyncTimeByDataSource(dataSourceID string, lastSyncTime string) {
 	dvmService.mu.Lock()
 	defer dvmService.mu.Unlock()
-	dvmService.lastSyncTime = lastSyncTime
+	dvmService.dataSourceSyncTimes[dataSourceID] = lastSyncTime
+	logger.Debugf("Data source '%s' sync time updated to: %s", dataSourceID, lastSyncTime)
+}
+
+// GetAllDataSourceSyncTimes 获取所有数据源的同步时间（用于调试/监控）
+func (dvmService *dataViewMonitorService) GetAllDataSourceSyncTimes() map[string]string {
+	dvmService.mu.RLock()
+	defer dvmService.mu.RUnlock()
+	result := make(map[string]string, len(dvmService.dataSourceSyncTimes))
+	for k, v := range dvmService.dataSourceSyncTimes {
+		result[k] = v
+	}
+	return result
 }
 
 // isOpenSearchOrIndexBaseDataSource 判断是否是opensearch或index_base数据源
@@ -1043,14 +1252,13 @@ func generateNativeFieldFeatures(fieldType string, metaField *interfaces.MetaFie
 	// 子字段
 	if subFields, ok := mappingConfig[interfaces.FieldProperty_Fields].(map[string]any); ok {
 		for subFieldName, subField := range subFields {
-			var fture interfaces.FieldFeature
 			if subFieldMap, ok := subField.(map[string]any); ok {
 				subFieldType := subFieldMap[interfaces.FieldProperty_Type].(string)
 				switch subFieldType {
 				case dtype.IndexBase_DataType_Keyword:
 					fieldsKeywordIgnoreAbove, _ := common.GetWithDefault(subFieldMap,
 						interfaces.FieldProperty_IgnoreAbove, 256)
-					fture = interfaces.FieldFeature{
+					features = append(features, interfaces.FieldFeature{
 						FeatureName: fmt.Sprintf("autoKeyword_%s.%s", metaField.FieldName, subFieldName),
 						FeatureType: interfaces.FieldFeatureType_Keyword,
 						Comment:     "自动同步生成的子字段精确匹配特征",
@@ -1058,10 +1266,10 @@ func generateNativeFieldFeatures(fieldType string, metaField *interfaces.MetaFie
 						IsDefault:   false,
 						IsNative:    true,
 						Config:      map[string]any{interfaces.FieldProperty_IgnoreAbove: fieldsKeywordIgnoreAbove},
-					}
+					})
 				case dtype.IndexBase_DataType_Text:
 					analyzer, _ := common.GetWithDefault(subFieldMap, interfaces.FieldProperty_Analyzer, "standard")
-					fture = interfaces.FieldFeature{
+					features = append(features, interfaces.FieldFeature{
 						FeatureName: fmt.Sprintf("autoFulltext_%s.%s", metaField.FieldName, subFieldName),
 						FeatureType: interfaces.FieldFeatureType_Fulltext,
 						Comment:     "自动同步生成的子字段全文检索特征",
@@ -1069,10 +1277,10 @@ func generateNativeFieldFeatures(fieldType string, metaField *interfaces.MetaFie
 						IsDefault:   false,
 						IsNative:    true,
 						Config:      map[string]any{interfaces.FieldProperty_Analyzer: analyzer},
-					}
+					})
 				case dtype.IndexBase_DataType_KNNVector:
 					dimension, _ := common.GetWithDefault(subFieldMap, interfaces.FieldProperty_Dimension, 768)
-					fture = interfaces.FieldFeature{
+					features = append(features, interfaces.FieldFeature{
 						FeatureName: fmt.Sprintf("autoVector_%s.%s", metaField.FieldName, subFieldName),
 						FeatureType: interfaces.FieldFeatureType_Vector,
 						Comment:     "自动同步生成的子字段向量特征",
@@ -1080,15 +1288,11 @@ func generateNativeFieldFeatures(fieldType string, metaField *interfaces.MetaFie
 						IsDefault:   false,
 						IsNative:    true,
 						Config:      map[string]any{interfaces.FieldProperty_Dimension: dimension},
-					}
+					})
 				}
 			}
-			features = append(features, fture)
 		}
 	}
-
-	// 启用每个类型的第一个特征
-	enableFirstFeatureOfEachType(features)
 
 	return features
 }
@@ -1108,7 +1312,7 @@ func enableFirstFeatureOfEachType(features []interfaces.FieldFeature) {
 	}
 }
 
-// MergeFeaturesOptimized 执行优化后的合并逻辑：Add + Delete + Patch(Config)
+// MergeFeaturesOptimized 执行优化后的合并逻辑Add + Delete + Patch(Config)
 func MergeFeaturesOptimized(dbFeatures []interfaces.FieldFeature, osFeatures []interfaces.FieldFeature) []interfaces.FieldFeature {
 	result := make([]interfaces.FieldFeature, 0)
 
@@ -1139,7 +1343,7 @@ func MergeFeaturesOptimized(dbFeatures []interfaces.FieldFeature, osFeatures []i
 
 		if existing, exists := dbNativeMap[fingerprint]; exists {
 			// 保留用户修改后的 Name, Comment和启用状态,更新物理层面的 Config (分词器、ignore_above 等)
-			if !reflect.DeepEqual(existing.Config, osF.Config) {
+			if !configEqual(existing.Config, osF.Config) {
 				// logger.Infof("检测到特征 [%s] 的物理配置变更，已同步新参数", existing.FeatureName)
 				existing.Config = osF.Config
 			}
@@ -1159,6 +1363,7 @@ func MergeFeaturesOptimized(dbFeatures []interfaces.FieldFeature, osFeatures []i
 
 	// 3. 消失的指纹不进入 result，即实现 DELETE
 	// 数据库中原有的原生特征，如果不在 activeFingerprints 里，就不再加入 result
+	// 如果os原始特征和自定义特征fingerprint一样，且default都为true，只保留自定义特征为true
 
 	return result
 }


### PR DESCRIPTION
…licit GC calls during data synchronization

[fix]修复同步视图的创建和更新的同名校验逻辑

refactor(dataViewMonitor): 多数据源同步隔离及添加变更检测逻辑

refactor(data_view): 替换资源类型为 PermissionResource

[test]fix test

[fix]fix 同步时查询视图列表报错

[fix]减少不必要的日志打印和内存占用

[fix]优化标记删除的逻辑和日志打印

[fix]补充日志打印

[fix]fix 特征对比

[fix]fix 字段特征校验

[fix修复不支持的字段特征类型